### PR TITLE
Add venue names and fix location display (maps links, dedupe)

### DIFF
--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -353,6 +353,11 @@ export default function CalendarView({
                           title={`${event.title} - ${event.kind === 31923 ? (event.start?.includes("-") ? new Date(event.start).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" }) : new Date(parseInt(event.start!) * 1000).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })) : "All day"}`}
                         >
                           <div className="font-semibold">{event.title}</div>
+                          {event.venueName && (
+                            <div className="text-[10px] opacity-95 truncate leading-tight">
+                              {event.venueName}
+                            </div>
+                          )}
                           {event.kind === 31923 && (
                             <div className="text-xs opacity-90">
                               {(event.start?.includes("-")
@@ -565,11 +570,20 @@ export default function CalendarView({
                               height: `${layoutItem.position.height}px`,
                               minHeight: "20px",
                             }}
-                            title={event.title}
+                            title={
+                              event.venueName
+                                ? `${event.title} — ${event.venueName}`
+                                : event.title
+                            }
                           >
                             <div className="font-semibold truncate">
                               {event.title}
                             </div>
+                            {event.venueName && (
+                              <div className="text-[10px] opacity-95 truncate leading-tight">
+                                {event.venueName}
+                              </div>
+                            )}
                             <div className="text-xs opacity-90">
                               {formatTime(eventStart)}
                               {event.end &&
@@ -751,6 +765,11 @@ export default function CalendarView({
                     <div className="font-semibold text-sm truncate">
                       {event.title}
                     </div>
+                    {event.venueName && (
+                      <div className="text-[10px] opacity-95 truncate leading-tight">
+                        {event.venueName}
+                      </div>
+                    )}
                     <div className="text-xs opacity-90">
                       {formatTime(start)}
                       {event.end && ` - ${formatTime(end)}`}
@@ -772,6 +791,11 @@ export default function CalendarView({
                   <div className="font-semibold text-sm truncate">
                     {event.title}
                   </div>
+                  {event.venueName && (
+                    <div className="text-[10px] opacity-95 truncate leading-tight">
+                      {event.venueName}
+                    </div>
+                  )}
                   <div className="text-xs text-gray-600">All day</div>
                 </div>
               ))}

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { googleMapsSearchUrl } from "@/utils/calendar";
 import { ClockIcon, MarkerIcon } from "./Icons";
 
 interface EventCardProps {
@@ -7,6 +8,8 @@ interface EventCardProps {
   startTime: string;
   endTime: string;
   location: string;
+  /** Primary venue display name when known (e.g. Meetup). */
+  venueName?: string;
   link?: string;
   description: string[];
   className?: string; // Allow custom background color
@@ -18,6 +21,7 @@ export default function EventCard({
   startTime,
   endTime,
   location,
+  venueName,
   description,
   link,
   className,
@@ -53,6 +57,12 @@ export default function EventCard({
           </div>
         </div>
 
+        {venueName && (
+          <p className="text-base sm:text-lg font-semibold text-gray-800">
+            {venueName}
+          </p>
+        )}
+
         {/* Time and location section */}
         <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-6 text-gray-600">
           <div className="flex items-center gap-2">
@@ -65,7 +75,7 @@ export default function EventCard({
             <MarkerIcon className="size-6 text-gray-500" />
             {location && location !== "Location TBD" ? (
               <a
-                href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(location)}`}
+                href={googleMapsSearchUrl(location)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-sm sm:text-base text-blue-600 hover:text-blue-800 underline hover:underline-offset-2"

--- a/src/components/EventDetailsModal.tsx
+++ b/src/components/EventDetailsModal.tsx
@@ -1,5 +1,9 @@
 import React from "react";
 import { CalendarEvent } from "../types/calendar";
+import {
+  getDisplayLocationLines,
+  googleMapsSearchUrl,
+} from "../utils/calendar";
 import { XIcon } from "./Icons";
 import { naddrEncode } from "applesauce-core/helpers";
 
@@ -13,6 +17,15 @@ export default function EventDetailsModal({
   onClose,
 }: EventDetailsModalProps) {
   if (!event) return null;
+
+  const displayLocationLines = getDisplayLocationLines(event);
+
+  const isMappableLocation = (line: string) => {
+    const t = line.trim();
+    if (!t) return false;
+    if (t === "Location TBD" || t === "Venue TBA") return false;
+    return true;
+  };
 
   const formatDate = (dateStr: string) => {
     return new Date(dateStr).toLocaleDateString("en-US", {
@@ -130,19 +143,28 @@ export default function EventDetailsModal({
             </div>
           )}
 
+          {/* Venue name (e.g. Meetup) */}
+          {event.venueName && (
+            <div className="mb-6">
+              <h4 className="font-semibold text-gray-900 mb-2">Venue</h4>
+              <p className="text-gray-800">{event.venueName}</p>
+            </div>
+          )}
+
           {/* Locations */}
-          {(event.location ||
-            (event.locations && event.locations.length > 0)) && (
+          {displayLocationLines.length > 0 && (
             <div className="mb-6">
               <h4 className="font-semibold text-gray-900 mb-2">
-                Location
-                {event.locations && event.locations.length > 1 ? "s" : ""}
+                Location{displayLocationLines.length > 1 ? "s" : ""}
               </h4>
               <div className="space-y-2">
-                {event.location && (
-                  <div className="flex items-center gap-2 text-gray-600">
+                {displayLocationLines.map((line, index) => (
+                  <div
+                    key={`${line}-${index}`}
+                    className="flex items-center gap-2 text-gray-600"
+                  >
                     <svg
-                      className="w-5 h-5"
+                      className="w-5 h-5 flex-shrink-0"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"
@@ -160,37 +182,21 @@ export default function EventDetailsModal({
                         d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
                       />
                     </svg>
-                    <span>{event.location}</span>
-                  </div>
-                )}
-                {event.locations &&
-                  event.locations.map((location, index) => (
-                    <div
-                      key={index}
-                      className="flex items-center gap-2 text-gray-600"
-                    >
-                      <svg
-                        className="w-5 h-5"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
+                    {isMappableLocation(line) ? (
+                      <a
+                        href={googleMapsSearchUrl(line)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 hover:text-blue-800 underline hover:underline-offset-2"
+                        title="Open in Google Maps"
                       >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                        />
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                        />
-                      </svg>
-                      <span>{location}</span>
-                    </div>
-                  ))}
+                        {line}
+                      </a>
+                    ) : (
+                      <span>{line}</span>
+                    )}
+                  </div>
+                ))}
               </div>
             </div>
           )}

--- a/src/lib/meetup.ts
+++ b/src/lib/meetup.ts
@@ -4,6 +4,7 @@ import { meetupConfig } from "@/config";
 // TypeScript interfaces for the GraphQL response
 export interface Venue {
   id: string;
+  name?: string;
   lat: number;
   lon: number;
   postalCode: string;
@@ -55,7 +56,11 @@ const EVENTS_QUERY = gql`
       lon
       link
       description
-      events {
+      events(
+        first: 200
+        filter: { status: [PAST, ACTIVE] }
+        sort: DESC
+      ) {
         edges {
           node {
             id
@@ -68,6 +73,7 @@ const EVENTS_QUERY = gql`
             howToFindUs
             venues {
               id
+              name
               lat
               lon
               postalCode

--- a/src/lib/meetup.ts
+++ b/src/lib/meetup.ts
@@ -57,7 +57,7 @@ const EVENTS_QUERY = gql`
       link
       description
       events(
-        first: 200
+        first: 0
         filter: { status: [PAST, ACTIVE] }
         sort: DESC
       ) {

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -117,6 +117,7 @@ export default function CalendarPage({
               description: event.description,
               location: getVenueAddress(event.venues),
               locations: event.venues?.map((v: any) => v.address) || [],
+              venueName: event.venues?.[0]?.name?.trim() || undefined,
               start: startTime.toString(),
               end: endTime.toString(),
               timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -680,6 +681,7 @@ export default function CalendarPage({
                           startTime={formatTime(event.start)}
                           endTime={event.end ? formatTime(event.end) : "TBA"}
                           location={event.location || "Location TBD"}
+                          venueName={event.venueName}
                           description={splitDescription(
                             event.description || "",
                           )}
@@ -706,6 +708,7 @@ export default function CalendarPage({
                           startTime={formatTime(event.start)}
                           endTime={event.end ? formatTime(event.end) : "TBA"}
                           location={event.location || "Location TBD"}
+                          venueName={event.venueName}
                           description={splitDescription(
                             event.description || "",
                           )}

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -130,6 +130,7 @@ export default function EventsPage({
                 startTime={formatTime(event.dateTime)}
                 endTime={event.endTime ? formatTime(event.endTime) : "TBA"}
                 location={getVenueAddress(event.venues)}
+                venueName={event.venues?.[0]?.name?.trim()}
                 description={splitDescription(event.description)}
                 link={event.eventUrl}
               />
@@ -170,6 +171,7 @@ export default function EventsPage({
                 startTime={formatTime(event.dateTime)}
                 endTime={event.endTime ? formatTime(event.endTime) : "TBA"}
                 location={getVenueAddress(event.venues)}
+                venueName={event.venues?.[0]?.name?.trim()}
                 description={splitDescription(event.description)}
                 link={event.eventUrl}
               />

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -16,6 +16,8 @@ export interface CalendarEvent {
   end?: string;
   location?: string;
   locations?: string[];
+  /** Display name of the primary venue (e.g. from Meetup). */
+  venueName?: string;
   geohash?: string;
   description?: string;
   timezone?: string;

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -186,6 +186,35 @@ export function formatEventTime(event: CalendarEvent): string {
   return "No time specified";
 }
 
+/** Google Maps search URL for an address or place string (shared with event UI). */
+export function googleMapsSearchUrl(query: string): string {
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
+}
+
+/**
+ * Deduplicates `location` vs `locations` for display (Nostr duplicates;
+ * Meetup full line + street-only lines).
+ */
+export function getDisplayLocationLines(event: CalendarEvent): string[] {
+  const primary = event.location?.trim() ?? "";
+  const raw = (event.locations ?? []).map((s) => s.trim()).filter(Boolean);
+
+  if (!primary && raw.length === 0) return [];
+
+  const out: string[] = [];
+
+  if (primary) out.push(primary);
+
+  for (const line of raw) {
+    if (primary && (line === primary || primary.includes(line))) continue;
+    if (out.includes(line)) continue;
+    if (out.some((o) => o !== line && o.includes(line))) continue;
+    out.push(line);
+  }
+
+  return out;
+}
+
 // Get event type label
 export function getEventTypeLabel(event: CalendarEvent): string {
   switch (event.kind) {


### PR DESCRIPTION
- Show venueName on calendar chips, EventCard, and EventDetailsModal.
- Add googleMapsSearchUrl + getDisplayLocationLines; wire Meetup venue name and types. Fixes #37