### PR TITLE
Add logger utility and global Nostr type declarations

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,20 @@
+// Global type declarations for window.nostr extension (NIP-07)
+declare global {
+  interface Window {
+    nostr?: {
+      getPublicKey(): Promise<string>;
+      signEvent(event: any): Promise<any>;
+      getRelays(): Promise<any>;
+      nip04?: {
+        encrypt?(pubkey: string, plaintext: string): Promise<string>;
+        decrypt?(pubkey: string, ciphertext: string): Promise<string>;
+      };
+      nip44?: {
+        encrypt?(pubkey: string, plaintext: string): Promise<string>;
+        decrypt?(pubkey: string, ciphertext: string): Promise<string>;
+      };
+    };
+  }
+}
+
+export {};

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,24 @@
+/**
+ * Logger utility for conditional development logging.
+ * Debug and info messages are silenced in production builds.
+ * Warn and error messages always appear.
+ */
+
+export const logger = {
+  debug: (message: string, data?: unknown) => {
+    if (process.env.NODE_ENV === "development") {
+      console.log(`[DEBUG] ${message}`, data);
+    }
+  },
+  info: (message: string, data?: unknown) => {
+    if (process.env.NODE_ENV === "development") {
+      console.info(`[INFO] ${message}`, data);
+    }
+  },
+  warn: (message: string, data?: unknown) => {
+    console.warn(`[WARN] ${message}`, data);
+  },
+  error: (message: string, error?: Error | unknown) => {
+    console.error(`[ERROR] ${message}`, error);
+  },
+};


### PR DESCRIPTION
## Summary
- Add production-safe logger utility (`src/utils/logger.ts`) — debug/info silenced in production, warn/error always active
- Add centralized `window.nostr` TypeScript declarations (`src/types/global.d.ts`) for NIP-07 browser extensions
- Pure additions, no existing files modified

## Test plan
- [ ] `pnpm build` passes with no errors
- [ ] No behavioral change — logger is unused in this PR, ready for adoption in subsequent PRs
- [ ] `global.d.ts` provides correct types for `window.nostr` extension interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)