### PR TITLE
Add standalone key management and enhance Nostr auth

### DIFF
--- a/config.json
+++ b/config.json
@@ -41,7 +41,17 @@
           "npub187w4ykkurr3e89mm0rg5p49x6lveqtq0pp0um7qyk6xyrpeerx3s84exkz",
           "npub1nv5c7sj2zxtjv7uayp2q2mneymm39mfp93wjhl5287y6yp6ey02qrsjhcn",
           "npub1yvscx9vrmpcmwcmydrm8lauqdpngum4ne8xmkgc2d4rcaxrx7tkswdwzdu"
-      ]   
+      ],
+      "whitelistedPubkeys": [
+          "d70d50091504b992d1838822af245d5f6b3a16b82d917acb7924cef61ed4acee",
+          "98e0e9fb4858f5d0e425a0f2c7e88fc13f652fdc5808e292743780c3f5689c53",
+          "3f9d525adc18e393977b78d140d4a6d7d9902c0f085fcdf804b68c41873919a3",
+          "9b298f424a1197267b9d2054056e7926f712ed212c5d2bfe8a3f89a2075923d4",
+          "2321831583d871b7636468f67ff78068668e6eb3c9cdbb230a6d478e9866f2ed"
+      ],
+      "blossom": {
+          "server": "https://mibo.us.nostria.app"
+      }
   },
   "pages": {
     "home": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@noble/curves": "^2.0.1",
+    "@scure/base": "^2.0.0",
     "@types/qrcode": "^1.5.6",
     "applesauce-common": "^5.0.0",
     "applesauce-core": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,12 @@ importers:
 
   .:
     dependencies:
+      '@noble/curves':
+        specifier: ^2.0.1
+        version: 2.0.1
+      '@scure/base':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6
@@ -45,9 +51,6 @@ importers:
       next:
         specifier: 15.3.4
         version: 15.3.4(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      nostr-tools:
-        specifier: ^2.19.4
-        version: 2.19.4(typescript@5.9.3)
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4

--- a/src/components/NostrLogin.tsx
+++ b/src/components/NostrLogin.tsx
@@ -16,6 +16,7 @@ export default function NostrLogin({
   const [showKeyInput, setShowKeyInput] = useState(false);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [newNsec, setNewNsec] = useState<string | null>(null);
 
   const handleExtensionLogin = async () => {
     setIsLoggingIn(true);
@@ -38,7 +39,10 @@ export default function NostrLogin({
     setIsLoggingIn(true);
     setError(null);
     try {
-      await login(); // Generate new key pair
+      const result = await login(); // Generate new key pair
+      if (result?.nsec) {
+        setNewNsec(result.nsec);
+      }
       onLoginSuccess?.();
     } catch (err) {
       setError("Failed to create account. Please try again.");
@@ -61,7 +65,9 @@ export default function NostrLogin({
       setPrivateKeyInput("");
       setShowKeyInput(false);
     } catch (err) {
-      setError("Invalid private key format. Please check and try again.");
+      setError(
+        err instanceof Error ? err.message : "Invalid private key format.",
+      );
     } finally {
       setIsLoggingIn(false);
     }
@@ -71,13 +77,59 @@ export default function NostrLogin({
     setPrivateKeyInput("");
     setShowKeyInput(false);
     setError(null);
-    // The actual logout is handled by the context
   };
 
   if (isLoading) {
     return (
       <div className={`p-4 ${className}`}>
         <div className="animate-pulse">Loading...</div>
+      </div>
+    );
+  }
+
+  // Show newly generated nsec with a warning to save it
+  if (newNsec) {
+    return (
+      <div
+        className={`p-4 bg-yellow-50 border-2 border-yellow-400 rounded-lg ${className}`}
+      >
+        <div className="space-y-4">
+          <div className="text-center">
+            <h3 className="text-lg font-bold text-yellow-800 mb-2">
+              Save Your Private Key!
+            </h3>
+            <p className="text-sm text-yellow-700">
+              This is your private key (nsec). You will{" "}
+              <strong>never</strong> see it again. Save it somewhere safe. Anyone
+              with this key can access your account.
+            </p>
+          </div>
+
+          <div className="bg-white p-3 rounded border border-yellow-300">
+            <p
+              className="text-xs font-mono break-all text-gray-900 select-all"
+              data-testid="new-nsec"
+            >
+              {newNsec}
+            </p>
+          </div>
+
+          <button
+            onClick={() => {
+              navigator.clipboard.writeText(newNsec).catch(() => {});
+            }}
+            className="w-full px-4 py-2 bg-yellow-500 text-white rounded-lg font-semibold hover:bg-yellow-600 transition-colors"
+          >
+            Copy to Clipboard
+          </button>
+
+          <button
+            onClick={() => setNewNsec(null)}
+            className="w-full px-4 py-2 bg-gray-200 text-gray-700 rounded-lg font-semibold hover:bg-gray-300 transition-colors"
+          >
+            I&apos;ve Saved My Key
+          </button>
+        </div>
       </div>
     );
   }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -45,6 +45,10 @@ export interface ApiConfig {
 export interface NostrConfig {
   relays: string[];
   whitelistedNpubs: string[];
+  whitelistedPubkeys?: string[];
+  blossom?: {
+    server: string;
+  };
 }
 
 export interface PageConfig {
@@ -119,20 +123,42 @@ export const socialLinks: SocialLink[] = Object.entries(externalLinks)
     ariaLabel: link.ariaLabel,
   }));
 
-// Whitelist functions (moved from whitelist.ts)
-import { normalizeToPubkey } from "applesauce-core/helpers";
+// Whitelist functions
+import { npubDecode } from "@/utils/bech32";
 
 export const WHITELISTED_NPUBS = whitelistedNpubs;
 
-// Convert npubs to hex for nostr relay filters
-export const WHITELISTED_PUBKEYS = WHITELISTED_NPUBS.map((npub) =>
-  normalizeToPubkey(npub),
-).filter((p) => p !== null);
+// Use pre-computed hex pubkeys from config if available, otherwise convert npubs at runtime
+function computeWhitelistedPubkeys(): string[] {
+  if (nostrConfig.whitelistedPubkeys?.length) {
+    return nostrConfig.whitelistedPubkeys;
+  }
+  return WHITELISTED_NPUBS.map((npub) => {
+    try {
+      return npubDecode(npub);
+    } catch {
+      return null;
+    }
+  }).filter((p): p is string => p !== null);
+}
 
-// Helper function to check if a pubkey is whitelisted
+export const WHITELISTED_PUBKEYS = computeWhitelistedPubkeys();
+
+// Blossom server config
+export const blossomConfig = nostrConfig.blossom;
+
+// Helper function to check if a pubkey is whitelisted (accepts hex or npub)
 export function isWhitelisted(pubkey: string): boolean {
-  const hex = normalizeToPubkey(pubkey);
-  if (!hex) return false;
+  let hex: string;
+  if (pubkey.startsWith("npub1")) {
+    try {
+      hex = npubDecode(pubkey);
+    } catch {
+      return false;
+    }
+  } else {
+    hex = pubkey;
+  }
   return WHITELISTED_PUBKEYS.includes(hex);
 }
 

--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -1,10 +1,11 @@
 import { isWhitelisted, nostrRelays } from "@/config";
 import {
-  generateSecretKey,
-  getPublicKey,
-  normalizeToSecretKey,
+  generateKeyPair,
+  getPubkey,
   npubEncode,
-} from "applesauce-core/helpers";
+  nsecEncode,
+  nsecDecode,
+} from "@/utils/bech32";
 import {
   createContext,
   ReactNode,
@@ -12,25 +13,6 @@ import {
   useEffect,
   useState,
 } from "react";
-
-// NIP-07 interface for browser extensions
-declare global {
-  interface Window {
-    nostr?: {
-      getPublicKey(): Promise<string>;
-      signEvent(event: any): Promise<any>;
-      getRelays(): Promise<any>;
-      nip04?: {
-        encrypt?(pubkey: string, plaintext: string): Promise<string>;
-        decrypt?(pubkey: string, ciphertext: string): Promise<string>;
-      };
-      nip44?: {
-        encrypt?(pubkey: string, plaintext: string): Promise<string>;
-        decrypt?(pubkey: string, ciphertext: string): Promise<string>;
-      };
-    };
-  }
-}
 
 export interface NostrUser {
   pubkey: string;
@@ -47,7 +29,7 @@ export interface NostrUser {
 
 interface NostrContextType {
   user: NostrUser | null;
-  login: (privateKeyOrNsec?: string) => Promise<void>;
+  login: (privateKeyOrNsec?: string) => Promise<{ nsec: string } | undefined>;
   loginWithExtension: () => Promise<void>;
   logout: () => void;
   isLoading: boolean;
@@ -67,12 +49,10 @@ export function NostrProvider({ children }: NostrProviderProps) {
   const [hasExtension, setHasExtension] = useState(false);
 
   useEffect(() => {
-    // Check for NIP-07 extension availability only on client side
     if (typeof window !== "undefined") {
       setHasExtension(!!window.nostr);
     }
 
-    // Check for stored user data on mount
     const storedUser = localStorage.getItem("nostr_user");
     if (storedUser) {
       try {
@@ -86,46 +66,50 @@ export function NostrProvider({ children }: NostrProviderProps) {
     setIsLoading(false);
   }, []);
 
-  const login = async (privateKeyOrNsec?: string) => {
+  const login = async (
+    privateKeyOrNsec?: string,
+  ): Promise<{ nsec: string } | undefined> => {
     try {
-      let privateKey: Uint8Array;
-      let pubkey: string;
+      let privkeyHex: string;
+      let pubkeyHex: string;
+      const isGenerated = !privateKeyOrNsec;
 
       if (privateKeyOrNsec) {
-        const normalizedKey = normalizeToSecretKey(privateKeyOrNsec);
-        if (!normalizedKey) {
-          throw new Error("Invalid private key or nsec format");
+        // Decode nsec to hex, or use hex directly
+        if (privateKeyOrNsec.startsWith("nsec1")) {
+          privkeyHex = nsecDecode(privateKeyOrNsec);
+        } else {
+          privkeyHex = privateKeyOrNsec;
         }
-        privateKey = normalizedKey;
+        pubkeyHex = await getPubkey(privkeyHex);
       } else {
         // Generate new key pair
-        privateKey = generateSecretKey();
+        const keyPair = await generateKeyPair();
+        privkeyHex = keyPair.privkeyHex;
+        pubkeyHex = keyPair.pubkeyHex;
       }
 
-      // Derive public key
-      pubkey = await getPublicKey(privateKey);
+      const npub = npubEncode(pubkeyHex);
+      const nsec = nsecEncode(privkeyHex);
 
-      // Create npub encoding - use the hex string directly
-      const npub = npubEncode(pubkey);
-
-      // Check if user is whitelisted
-      if (!isWhitelisted(npub)) {
-        console.log("🚫 User not whitelisted:", npub);
+      // Only check whitelist for existing keys, not newly generated ones
+      if (!isGenerated && !isWhitelisted(pubkeyHex)) {
         throw new Error(
-          "This account is not whitelisted for calendar events. Only whitelisted users can access the calendar.",
+          "This account is not whitelisted. Only whitelisted users can publish content.",
         );
       }
 
-      console.log("✅ User is whitelisted:", npub);
-
       const userData: NostrUser = {
-        pubkey,
+        pubkey: pubkeyHex,
         npub,
-        privateKey: privateKey.toString(), // Store for signing events
+        privateKey: nsec,
       };
 
       setUser(userData);
       localStorage.setItem("nostr_user", JSON.stringify(userData));
+
+      // Return nsec for newly generated accounts so UI can display it
+      return isGenerated ? { nsec } : undefined;
     } catch (error) {
       console.error("Login failed:", error);
       throw error;
@@ -133,133 +117,77 @@ export function NostrProvider({ children }: NostrProviderProps) {
   };
 
   const fetchUserMetadata = async (pubkey: string) => {
-    console.log("🔍 Fetching metadata for pubkey:", pubkey);
-
     try {
-      // Follow plektos implementation - use WebSocket connections to relays
-      // This avoids CORS issues entirely
       const relays = nostrRelays;
 
-      console.log("🌐 Connecting to relays for metadata:", relays);
-
-      // Create filter for kind 0 (metadata) events
       const filter = {
         kinds: [0],
         authors: [pubkey],
         limit: 1,
       };
 
-      console.log("📤 Using metadata filter:", filter);
-
-      // Try each relay until we get metadata
       for (const relayUrl of relays) {
-        console.log(`🔌 Connecting to relay: ${relayUrl}`);
-
         try {
-          // Create WebSocket connection
           const ws = new WebSocket(relayUrl);
 
-          // Create a promise that resolves when we get the metadata
           const metadataPromise = new Promise((resolve, reject) => {
             const timeout = setTimeout(() => {
-              console.log(`⏰ Timeout on ${relayUrl}`);
               ws.close();
               reject(new Error("Timeout"));
             }, 5000);
 
             ws.onopen = () => {
-              console.log(`✅ Connected to ${relayUrl}`);
-
-              // Send REQ message for metadata
-              const reqMessage = JSON.stringify([
-                "REQ",
-                "metadata-sub",
-                filter,
-              ]);
-
-              console.log(`📤 Sending REQ to ${relayUrl}:`, reqMessage);
-              ws.send(reqMessage);
+              ws.send(JSON.stringify(["REQ", "metadata-sub", filter]));
             };
 
             ws.onmessage = (event) => {
               try {
                 const message = JSON.parse(event.data);
-                console.log(`📨 Message from ${relayUrl}:`, message);
 
                 if (message[0] === "EVENT") {
-                  const [type, subscriptionId, nostrEvent] = message;
+                  const [, subscriptionId, nostrEvent] = message;
 
                   if (subscriptionId === "metadata-sub") {
                     clearTimeout(timeout);
-                    console.log(
-                      `🎯 Found metadata event from ${relayUrl}:`,
-                      nostrEvent,
-                    );
-
                     try {
                       const metadata = JSON.parse(nostrEvent.content);
-                      console.log(
-                        `✅ Successfully parsed metadata from ${relayUrl}:`,
-                        metadata,
-                      );
-
-                      if (metadata.picture) {
-                        console.log(
-                          `🖼️ Found picture URL: ${metadata.picture}`,
-                        );
-                      } else {
-                        console.log(`⚠️ No picture in metadata for ${pubkey}`);
-                      }
-
                       ws.close();
                       resolve(metadata);
                     } catch (parseError) {
-                      console.error(
-                        `❌ Failed to parse metadata content:`,
-                        parseError,
-                      );
-                      console.log("Raw content:", nostrEvent.content);
+                      ws.close();
                       reject(parseError);
                     }
                   }
                 } else if (message[0] === "EOSE") {
-                  console.log(`📭 End of stored events from ${relayUrl}`);
                   clearTimeout(timeout);
                   ws.close();
                   reject(new Error("No metadata found"));
                 }
               } catch (error) {
-                console.error(
-                  `💥 Error parsing message from ${relayUrl}:`,
-                  error,
-                );
+                clearTimeout(timeout);
+                ws.close();
+                reject(error);
               }
             };
 
-            ws.onerror = (error) => {
-              console.error(`💥 WebSocket error from ${relayUrl}:`, error);
+            ws.onerror = () => {
               clearTimeout(timeout);
-              reject(error);
+              reject(new Error("WebSocket error"));
             };
 
             ws.onclose = () => {
-              console.log(`🔌 Closed connection to ${relayUrl}`);
               clearTimeout(timeout);
             };
           });
 
-          // Wait for metadata or timeout
           return await metadataPromise;
-        } catch (error) {
-          console.warn(`⚠️ Failed to connect to ${relayUrl}:`, error);
+        } catch {
           // Continue to next relay
         }
       }
 
-      console.log(`❌ No metadata found for pubkey ${pubkey} from any relay`);
       return null;
-    } catch (error) {
-      console.error("💥 Critical error in fetchUserMetadata:", error);
+    } catch {
       return null;
     }
   };
@@ -272,30 +200,23 @@ export function NostrProvider({ children }: NostrProviderProps) {
     }
 
     try {
-      // Request public key from extension
       const pubkey = await window.nostr.getPublicKey();
       const npub = npubEncode(pubkey);
 
-      // Check if the user is whitelisted
-      if (!isWhitelisted(npub)) {
-        console.log("🚫 User not whitelisted:", npub);
+      if (!isWhitelisted(pubkey)) {
         throw new Error(
-          "This account is not whitelisted for calendar events. Only whitelisted users can access the calendar.",
+          "This account is not whitelisted. Only whitelisted users can publish content.",
         );
       }
-
-      console.log("✅ User is whitelisted:", npub);
 
       const userData: NostrUser = {
         pubkey,
         npub,
-        // No private key when using extension - extension handles signing
       };
 
       setUser(userData);
       localStorage.setItem("nostr_user", JSON.stringify(userData));
 
-      // Fetch metadata in background
       fetchUserMetadata(pubkey).then((metadata) => {
         if (metadata) {
           setUser((prev) => (prev ? { ...prev, metadata } : null));
@@ -307,9 +228,7 @@ export function NostrProvider({ children }: NostrProviderProps) {
       });
     } catch (error) {
       console.error("Extension login failed:", error);
-      throw new Error(
-        "Failed to connect to nostr extension. Please try again.",
-      );
+      throw error;
     }
   };
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,20 @@
+// Global type declarations for window.nostr extension (NIP-07)
+declare global {
+  interface Window {
+    nostr?: {
+      getPublicKey(): Promise<string>;
+      signEvent(event: any): Promise<any>;
+      getRelays(): Promise<any>;
+      nip04?: {
+        encrypt?(pubkey: string, plaintext: string): Promise<string>;
+        decrypt?(pubkey: string, ciphertext: string): Promise<string>;
+      };
+      nip44?: {
+        encrypt?(pubkey: string, plaintext: string): Promise<string>;
+        decrypt?(pubkey: string, ciphertext: string): Promise<string>;
+      };
+    };
+  }
+}
+
+export {};

--- a/src/utils/bech32.ts
+++ b/src/utils/bech32.ts
@@ -1,0 +1,72 @@
+import { bech32 } from "@scure/base";
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function randomBytes(n: number): Uint8Array {
+  const bytes = new Uint8Array(n);
+  if (typeof crypto !== "undefined" && crypto.getRandomValues) {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < n; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  return bytes;
+}
+
+// Lazy-load schnorr to avoid Turbopack ESM resolution issues at import time
+let _schnorr: typeof import("@noble/curves/secp256k1.js").schnorr | null = null;
+
+async function getSchnorr() {
+  if (!_schnorr) {
+    const mod = await import("@noble/curves/secp256k1.js");
+    _schnorr = mod.schnorr;
+  }
+  return _schnorr;
+}
+
+export function npubEncode(hexPubkey: string): string {
+  return bech32.encode("npub", bech32.toWords(hexToBytes(hexPubkey)));
+}
+
+export function npubDecode(npub: string): string {
+  const { words } = bech32.decode(npub as `${string}1${string}`);
+  return bytesToHex(new Uint8Array(bech32.fromWords(words)));
+}
+
+export function nsecEncode(privkey: string | Uint8Array): string {
+  const bytes = typeof privkey === "string" ? hexToBytes(privkey) : privkey;
+  return bech32.encode("nsec", bech32.toWords(bytes));
+}
+
+export function nsecDecode(nsec: string): string {
+  const { words } = bech32.decode(nsec as `${string}1${string}`);
+  return bytesToHex(new Uint8Array(bech32.fromWords(words)));
+}
+
+/** Generate a new Nostr key pair. Returns hex privkey and hex pubkey. */
+export async function generateKeyPair(): Promise<{ privkeyHex: string; pubkeyHex: string }> {
+  const privkey = randomBytes(32);
+  const s = await getSchnorr();
+  const pubkey = s.getPublicKey(privkey);
+  return {
+    privkeyHex: bytesToHex(privkey),
+    pubkeyHex: bytesToHex(pubkey),
+  };
+}
+
+/** Derive the x-only public key from a hex private key. */
+export async function getPubkey(privkeyHex: string): Promise<string> {
+  const s = await getSchnorr();
+  return bytesToHex(s.getPublicKey(hexToBytes(privkeyHex)));
+}


### PR DESCRIPTION
## Summary
- New `src/utils/bech32.ts` — standalone npub/nsec encode/decode, key generation using `@noble/curves` + `@scure/base`, replacing `applesauce-core/helpers` for key operations
- Updated `NostrContext` — async key ops, whitelist bypass for newly generated accounts, `login()` returns nsec for new keys, stores nsec (not hex) as private key
- Updated `NostrLogin` — NSEC display flow with yellow warning box, copy button, and "I've Saved My Key" confirmation
- Updated `config/index.ts` — pre-computed hex pubkeys (`whitelistedPubkeys`), Blossom server config, `computeWhitelistedPubkeys()` helper
- Updated `config.json` — added `whitelistedPubkeys` array and `blossom` server config
- New dependencies: `@noble/curves`, `@scure/base`

## Test plan
- [ ] `pnpm build` passes
- [ ] Extension login (NIP-07) works as before
- [ ] Key generation works and shows NSEC display with copy/save flow
- [ ] Existing key login (nsec or hex) works
- [ ] Whitelist enforcement still works for imported keys
- [ ] Newly generated accounts bypass whitelist check

🤖 Generated with [Claude Code](https://claude.com/claude-code)