### PR TITLE
Only trigger DNS workflow on terraform changes

### DIFF
--- a/.github/workflows/dns.yml
+++ b/.github/workflows/dns.yml
@@ -3,6 +3,8 @@ name: DNS
 on:
   push:
     branches: ["master"]
+    paths:
+      - "terraform/**"
 
 permissions:
   contents: write # Required to update state


### PR DESCRIPTION
## Summary
- The DNS/Terraform workflow was running on every push to master, even when only frontend code changed
- Added a `paths` filter so it only triggers when files under `terraform/` are modified

## Test plan
- [ ] Merge a non-terraform change and confirm the DNS workflow does not run
- [ ] Make a terraform change and confirm the DNS workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)