### PR TITLE
Port committee openings, EventActions fix, education enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-leaflet": "^5.0.0",
+    "react-markdown": "^10.1.0",
     "rxjs": "^7.8.2",
     "window.nostrdb.js": "^0.5.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       react-leaflet:
         specifier: ^5.0.0
         version: 5.0.0(leaflet@1.9.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.7)(react@19.2.3)
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
@@ -686,6 +689,9 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -723,6 +729,9 @@ packages:
 
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -785,6 +794,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.51.0':
     resolution: {integrity: sha512-mM/JRQOzhVN1ykejrvwnBRV3+7yTKK8tVANVN3o1O0t0v7o+jqdVu9crPy5Y9dov15TJk/FTIgoUGHrTOVL3Zg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -1085,12 +1097,24 @@ packages:
   caniuse-lite@1.0.30001762:
     resolution: {integrity: sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -1111,6 +1135,9 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1406,6 +1433,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1611,6 +1641,12 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
@@ -1623,6 +1659,9 @@ packages:
   hono@4.11.3:
     resolution: {integrity: sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==}
     engines: {node: '>=16.9.0'}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -1654,6 +1693,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -1661,6 +1703,12 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1697,6 +1745,9 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1716,6 +1767,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -1961,8 +2015,20 @@ packages:
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
 
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
   mdast-util-to-markdown@2.1.2:
     resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
@@ -2228,6 +2294,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -2309,6 +2378,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -2358,6 +2430,12 @@ packages:
       react: ^19.2.3
       react-dom: ^19.2.3
 
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: ^19.2.3
+
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
@@ -2376,6 +2454,9 @@ packages:
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
@@ -2519,6 +2600,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -2565,6 +2649,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -2580,6 +2667,12 @@ packages:
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -2623,6 +2716,9 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
@@ -2687,6 +2783,9 @@ packages:
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
 
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
@@ -3351,6 +3450,10 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
 
   '@types/geojson@7946.0.16': {}
@@ -3388,6 +3491,8 @@ snapshots:
   '@types/react@19.2.7':
     dependencies:
       csstype: 3.2.3
+
+  '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
@@ -3481,6 +3586,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.51.0
       eslint-visitor-keys: 4.2.1
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     optional: true
@@ -3901,12 +4008,20 @@ snapshots:
 
   caniuse-lite@1.0.30001762: {}
 
+  ccount@2.0.1: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
   character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   client-only@0.0.1: {}
 
@@ -3925,6 +4040,8 @@ snapshots:
   color-name@1.1.4: {}
 
   colorette@2.0.20: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   concat-map@0.0.1: {}
 
@@ -4352,6 +4469,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -4572,6 +4691,30 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   help-me@5.0.0: {}
 
   hermes-estree@0.25.1: {}
@@ -4581,6 +4724,8 @@ snapshots:
       hermes-estree: 0.25.1
 
   hono@4.11.3: {}
+
+  html-url-attributes@3.0.1: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -4609,6 +4754,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -4616,6 +4763,13 @@ snapshots:
       side-channel: 1.1.0
 
   ipaddr.js@1.9.1: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -4661,6 +4815,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-decimal@2.0.1: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -4680,6 +4836,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
 
   is-map@2.0.3: {}
 
@@ -4905,10 +5063,61 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
       unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
 
   mdast-util-to-markdown@2.1.2:
     dependencies:
@@ -5267,6 +5476,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.2.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
@@ -5353,6 +5572,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  property-information@7.1.0: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -5402,6 +5623,24 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
+  react-markdown@10.1.0(@types/react@19.2.7)(react@19.2.3):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.7
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.3
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   react@19.2.3: {}
 
   real-require@0.2.0: {}
@@ -5434,6 +5673,14 @@ snapshots:
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
 
   remark-stringify@11.0.0:
     dependencies:
@@ -5646,6 +5893,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   split2@4.2.0: {}
 
   stable-hash@0.0.5: {}
@@ -5715,6 +5964,11 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -5724,6 +5978,14 @@ snapshots:
   strip-json-comments@3.1.1: {}
 
   strip-json-comments@5.0.3: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.3):
     dependencies:
@@ -5756,6 +6018,8 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
 
@@ -5848,6 +6112,10 @@ snapshots:
       vfile: 6.0.3
 
   unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
 

--- a/src/components/CommitteeFormModal.tsx
+++ b/src/components/CommitteeFormModal.tsx
@@ -1,0 +1,209 @@
+import React, { useState } from "react";
+import {
+  Committee,
+  buildCommitteeEvent,
+  publishCommittee,
+} from "@/utils/committeeEvents";
+
+interface CommitteeFormModalProps {
+  editCommittee?: Committee | null;
+  onDone: () => void;
+  onCancel: () => void;
+  pubkey?: string;
+  signEvent?: (event: { kind: number; content: string; tags: string[][]; created_at: number }) => Promise<Record<string, unknown>>;
+}
+
+export default function CommitteeFormModal({
+  editCommittee,
+  onDone,
+  onCancel,
+  pubkey,
+  signEvent,
+}: CommitteeFormModalProps) {
+  const isEditing = !!editCommittee;
+  const [title, setTitle] = useState(editCommittee?.title || "");
+  const [dTag, setDTag] = useState(editCommittee?.dTag || "");
+  const [description, setDescription] = useState(editCommittee?.description || "");
+  const [meetingSchedule, setMeetingSchedule] = useState(editCommittee?.meetingSchedule || "");
+  const [openings, setOpenings] = useState(editCommittee?.openings || 0);
+  const [image, setImage] = useState(editCommittee?.image || "");
+  const [topicTags, setTopicTags] = useState(editCommittee?.tags?.join(", ") || "");
+  const [publishing, setPublishing] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleTitleChange = (val: string) => {
+    setTitle(val);
+    // Auto-generate slug from title if not editing
+    if (!isEditing && !dTag) {
+      setDTag(val.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "").slice(0, 64));
+    }
+  };
+
+  const handlePublish = async () => {
+    if (!title.trim()) { setError("Title is required"); return; }
+    if (!dTag.trim()) { setError("Slug is required"); return; }
+
+    setPublishing(true);
+    setError("");
+
+    try {
+      if (!pubkey && !window.nostr) {
+        setError("You must be logged in to publish.");
+        setPublishing(false);
+        return;
+      }
+
+      const tagList = topicTags.split(",").map((t) => t.trim()).filter(Boolean);
+
+      const unsignedEvent = buildCommitteeEvent({
+        dTag: dTag.trim(),
+        title: title.trim(),
+        description: description.trim(),
+        image: image.trim() || undefined,
+        meetingSchedule: meetingSchedule.trim() || undefined,
+        openings,
+        topicTags: tagList,
+      });
+
+      let signedEvent;
+      if (signEvent && pubkey) {
+        signedEvent = await signEvent(unsignedEvent as { kind: number; content: string; tags: string[][]; created_at: number });
+      } else if (window.nostr) {
+        const pk = await window.nostr.getPublicKey();
+        signedEvent = await window.nostr.signEvent({ ...unsignedEvent, pubkey: pk });
+      }
+      const success = await publishCommittee(signedEvent);
+
+      if (success) {
+        onDone();
+      } else {
+        setError("Failed to publish to relays. Please try again.");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+    setPublishing(false);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={onCancel}>
+      <div
+        className="bg-white rounded-lg max-w-md w-full p-6 shadow-xl"
+        data-testid="committee-form-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-xl font-bold text-gray-900 mb-4">
+          {isEditing ? "Edit Committee" : "Create Committee"}
+        </h3>
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Title *</label>
+            <input
+              data-testid="committee-title"
+              type="text"
+              value={title}
+              onChange={(e) => handleTitleChange(e.target.value)}
+              placeholder="e.g. Events Committee"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Slug *</label>
+            <input
+              data-testid="committee-slug"
+              type="text"
+              value={dTag}
+              onChange={(e) => setDTag(e.target.value.replace(/[^a-z0-9-]/g, ""))}
+              placeholder="e.g. events"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent font-mono"
+              disabled={isEditing}
+            />
+            <p className="text-xs text-gray-500 mt-1">Used as a unique identifier (lowercase, dashes only)</p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+            <textarea
+              data-testid="committee-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What does this committee do?"
+              rows={3}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Meeting Schedule</label>
+            <input
+              data-testid="committee-schedule"
+              type="text"
+              value={meetingSchedule}
+              onChange={(e) => setMeetingSchedule(e.target.value)}
+              placeholder="e.g. First Thursday at 7 PM"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Open Positions</label>
+            <input
+              data-testid="committee-openings"
+              type="number"
+              value={openings}
+              onChange={(e) => setOpenings(parseInt(e.target.value, 10) || 0)}
+              min={0}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Image URL</label>
+            <input
+              data-testid="committee-image"
+              type="text"
+              value={image}
+              onChange={(e) => setImage(e.target.value)}
+              placeholder="https://..."
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Tags (comma-separated)</label>
+            <input
+              data-testid="committee-tags"
+              type="text"
+              value={topicTags}
+              onChange={(e) => setTopicTags(e.target.value)}
+              placeholder="governance, fundraising, outreach"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"
+            />
+          </div>
+
+          {error && <p className="text-red-600 text-sm">{error}</p>}
+        </div>
+
+        <div className="flex gap-3 mt-6">
+          <button
+            onClick={onCancel}
+            data-testid="committee-cancel"
+            className="flex-1 px-4 py-2 border border-gray-300 rounded-lg text-gray-700 font-semibold hover:bg-gray-50 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            data-testid="committee-publish"
+            onClick={handlePublish}
+            disabled={publishing}
+            className="flex-1 px-4 py-2 bg-bitcoin-orange text-white rounded-lg font-semibold hover:bg-bitcoin-orange-hover transition-colors disabled:opacity-50"
+          >
+            {publishing ? "Publishing..." : isEditing ? "Update" : "Create"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CommitteeMemberFormModal.tsx
+++ b/src/components/CommitteeMemberFormModal.tsx
@@ -1,0 +1,174 @@
+import React, { useState } from "react";
+import {
+  CommitteeMember,
+  buildCommitteeMemberEvent,
+  publishCommitteeMember,
+} from "@/utils/committeeEvents";
+
+interface CommitteeMemberFormModalProps {
+  committeeCoordinate: string;
+  editMember?: CommitteeMember | null;
+  onDone: () => void;
+  onCancel: () => void;
+  pubkey?: string;
+  signEvent?: (event: { kind: number; content: string; tags: string[][]; created_at: number }) => Promise<Record<string, unknown>>;
+}
+
+export default function CommitteeMemberFormModal({
+  committeeCoordinate,
+  editMember,
+  onDone,
+  onCancel,
+  pubkey,
+  signEvent,
+}: CommitteeMemberFormModalProps) {
+  const isEditing = !!editMember;
+  const [name, setName] = useState(editMember?.name || "");
+  const [role, setRole] = useState(editMember?.role || "");
+  const [email, setEmail] = useState(editMember?.email || "");
+  const [phone, setPhone] = useState(editMember?.phone || "");
+  const [publishing, setPublishing] = useState(false);
+  const [error, setError] = useState("");
+
+  const handlePublish = async () => {
+    if (!name.trim()) { setError("Name is required"); return; }
+
+    setPublishing(true);
+    setError("");
+
+    try {
+      if (!pubkey && !window.nostr) {
+        setError("You must be logged in to publish.");
+        setPublishing(false);
+        return;
+      }
+
+      // Generate dTag: slug from name + random suffix (or reuse for edits)
+      const dTag = isEditing
+        ? editMember!.dTag
+        : `${name.toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 30)}-${Date.now().toString(36)}`;
+
+      const unsignedEvent = buildCommitteeMemberEvent({
+        committeeCoordinate,
+        dTag,
+        role,
+        name: name.trim(),
+        email: email.trim() || undefined,
+        phone: phone.trim() || undefined,
+      });
+
+      let signedEvent;
+      if (signEvent && pubkey) {
+        signedEvent = await signEvent(unsignedEvent as { kind: number; content: string; tags: string[][]; created_at: number });
+      } else if (window.nostr) {
+        const pk = await window.nostr.getPublicKey();
+        signedEvent = await window.nostr.signEvent({ ...unsignedEvent, pubkey: pk });
+      }
+      const success = await publishCommitteeMember(signedEvent);
+
+      if (success) {
+        onDone();
+      } else {
+        setError("Failed to publish to relays. Please try again.");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+    setPublishing(false);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={onCancel}>
+      <div
+        className="bg-white rounded-lg max-w-md w-full p-6 shadow-xl"
+        data-testid="member-form-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-xl font-bold text-gray-900 mb-4">
+          {isEditing ? "Edit Member" : "Add Member"}
+        </h3>
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Name *</label>
+            <input
+              data-testid="member-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Full name"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Role</label>
+            <input
+              data-testid="member-role"
+              type="text"
+              list="role-suggestions"
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+              placeholder="e.g. Chair, Vice Chair, Secretary..."
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"
+            />
+            <datalist id="role-suggestions">
+              <option value="Chair" />
+              <option value="Vice Chair" />
+              <option value="Secretary" />
+              <option value="Treasurer" />
+              <option value="Member" />
+              <option value="Committee Member" />
+              <option value="Parliamentarian" />
+              <option value="Sergeant at Arms" />
+            </datalist>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+            <input
+              data-testid="member-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="email@example.com"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Phone</label>
+            <input
+              data-testid="member-phone"
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              placeholder="(816) 555-0000"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"
+            />
+          </div>
+
+          {error && <p className="text-red-600 text-sm">{error}</p>}
+        </div>
+
+        <div className="flex gap-3 mt-6">
+          <button
+            onClick={onCancel}
+            data-testid="member-cancel"
+            className="flex-1 px-4 py-2 border border-gray-300 rounded-lg text-gray-700 font-semibold hover:bg-gray-50 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            data-testid="member-publish"
+            onClick={handlePublish}
+            disabled={publishing}
+            className="flex-1 px-4 py-2 bg-bitcoin-orange text-white rounded-lg font-semibold hover:bg-bitcoin-orange-hover transition-colors disabled:opacity-50"
+          >
+            {publishing ? "Publishing..." : isEditing ? "Update" : "Add Member"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CommitteeOpeningFormModal.tsx
+++ b/src/components/CommitteeOpeningFormModal.tsx
@@ -1,0 +1,134 @@
+import React, { useState } from "react";
+import {
+  CommitteeOpening,
+  buildCommitteeOpeningEvent,
+  publishCommitteeOpening,
+} from "@/utils/committeeEvents";
+
+interface CommitteeOpeningFormModalProps {
+  committeeCoordinate: string;
+  editOpening?: CommitteeOpening | null;
+  onDone: () => void;
+  onCancel: () => void;
+  pubkey?: string;
+  signEvent?: (event: { kind: number; content: string; tags: string[][]; created_at: number }) => Promise<Record<string, unknown>>;
+}
+
+export default function CommitteeOpeningFormModal({
+  committeeCoordinate,
+  editOpening,
+  onDone,
+  onCancel,
+  pubkey,
+  signEvent,
+}: CommitteeOpeningFormModalProps) {
+  const isEditing = !!editOpening;
+  const [title, setTitle] = useState(editOpening?.title || "");
+  const [description, setDescription] = useState(editOpening?.description || "");
+  const [publishing, setPublishing] = useState(false);
+  const [error, setError] = useState("");
+
+  const handlePublish = async () => {
+    if (!title.trim()) { setError("Title is required"); return; }
+
+    setPublishing(true);
+    setError("");
+
+    try {
+      if (!pubkey && !window.nostr) {
+        setError("You must be logged in to publish.");
+        setPublishing(false);
+        return;
+      }
+
+      const dTag = isEditing
+        ? editOpening!.dTag
+        : `opening-${Date.now().toString(36)}`;
+
+      const unsignedEvent = buildCommitteeOpeningEvent({
+        committeeCoordinate,
+        dTag,
+        title: title.trim(),
+        description: description.trim() || undefined,
+      });
+
+      let signedEvent;
+      if (signEvent && pubkey) {
+        signedEvent = await signEvent(unsignedEvent as { kind: number; content: string; tags: string[][]; created_at: number });
+      } else if (window.nostr) {
+        const pk = await window.nostr.getPublicKey();
+        signedEvent = await window.nostr.signEvent({ ...unsignedEvent, pubkey: pk });
+      }
+      const success = await publishCommitteeOpening(signedEvent);
+
+      if (success) {
+        onDone();
+      } else {
+        setError("Failed to publish to relays. Please try again.");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+    setPublishing(false);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={onCancel}>
+      <div
+        className="bg-white rounded-lg max-w-md w-full p-6 shadow-xl"
+        data-testid="opening-form-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-xl font-bold text-gray-900 mb-4">
+          {isEditing ? "Edit Opening" : "Add Opening"}
+        </h3>
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Title *</label>
+            <input
+              data-testid="opening-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g. Treasurer"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+            <textarea
+              data-testid="opening-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Describe the role, responsibilities, qualifications..."
+              rows={3}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"
+            />
+          </div>
+
+          {error && <p className="text-red-600 text-sm">{error}</p>}
+        </div>
+
+        <div className="flex gap-3 mt-6">
+          <button
+            onClick={onCancel}
+            data-testid="opening-cancel"
+            className="flex-1 px-4 py-2 border border-gray-300 rounded-lg text-gray-700 font-semibold hover:bg-gray-50 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            data-testid="opening-publish"
+            onClick={handlePublish}
+            disabled={publishing}
+            className="flex-1 px-4 py-2 bg-bitcoin-orange text-white rounded-lg font-semibold hover:bg-bitcoin-orange-hover transition-colors disabled:opacity-50"
+          >
+            {publishing ? "Publishing..." : isEditing ? "Update" : "Add Opening"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/EventActions.tsx
+++ b/src/components/EventActions.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
 
 export interface EventAction {
   label: string;
@@ -18,28 +18,31 @@ interface EventActionsProps {
   onEdit?: () => void;
 }
 
-export default function EventActions({
-  event,
-  extraActions,
-  className,
-  onDelete,
-  onEdit,
-}: EventActionsProps) {
+export default function EventActions({ event, extraActions, className, onDelete, onEdit }: EventActionsProps) {
   const [open, setOpen] = useState(false);
   const [showRaw, setShowRaw] = useState(false);
   const [copied, setCopied] = useState<string | null>(null);
-  const ref = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState<{ top: number; right: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
-  // Close on outside click
+  const updatePosition = useCallback(() => {
+    if (triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setPosition({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
+    }
+  }, []);
+
   useEffect(() => {
     function handleClick(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setOpen(false);
+        setShowRaw(false);
       }
     }
-    if (open) document.addEventListener("mousedown", handleClick);
+    if (open || showRaw) document.addEventListener("mousedown", handleClick);
     return () => document.removeEventListener("mousedown", handleClick);
-  }, [open]);
+  }, [open, showRaw]);
 
   const eventId = event.id as string | undefined;
   const eventKind = event.kind as number | undefined;
@@ -50,12 +53,14 @@ export default function EventActions({
       setCopied(label);
       setTimeout(() => setCopied(null), 2000);
     } catch {
-      // clipboard not available
+      // fallback
     }
   };
 
   const handleShare = async () => {
-    const text = eventId ? `nostr:${eventId}` : JSON.stringify(event);
+    const text = eventId
+      ? `nostr:${eventId}`
+      : JSON.stringify(event);
     await copyToClipboard(text, "Share link");
     setOpen(false);
   };
@@ -73,8 +78,14 @@ export default function EventActions({
   };
 
   const handleViewRaw = () => {
+    updatePosition();
     setShowRaw(!showRaw);
     setOpen(false);
+  };
+
+  const toggleMenu = () => {
+    updatePosition();
+    setOpen(!open);
   };
 
   const actions: EventAction[] = [
@@ -107,10 +118,7 @@ export default function EventActions({
           {
             label: "Edit",
             icon: "✏️",
-            onClick: () => {
-              onEdit();
-              setOpen(false);
-            },
+            onClick: () => { onEdit(); setOpen(false); },
           },
         ]
       : []),
@@ -119,10 +127,7 @@ export default function EventActions({
           {
             label: "Delete",
             icon: "🗑️",
-            onClick: () => {
-              onDelete();
-              setOpen(false);
-            },
+            onClick: () => { onDelete(); setOpen(false); },
           },
         ]
       : []),
@@ -130,37 +135,42 @@ export default function EventActions({
   ];
 
   return (
-    <div ref={ref} className="relative">
+    <div ref={containerRef} className="relative">
       {/* Trigger button */}
       <button
-        onClick={() => setOpen(!open)}
+        ref={triggerRef}
+        onClick={toggleMenu}
         title="Actions"
         className={`px-2 py-1 rounded hover:bg-gray-100 transition-colors text-gray-400 hover:text-gray-700 font-bold text-lg leading-none ${className || ""}`}
       >
         ...
       </button>
 
-      {/* Dropdown */}
-      {open && (
-        <div className="absolute right-0 top-full mt-1 z-50 bg-white border border-gray-200 rounded-lg shadow-lg py-1 min-w-[180px]">
+      {/* Dropdown — fixed positioning to escape overflow clipping */}
+      {open && position && (
+        <div
+          className="fixed bg-white border border-gray-200 rounded-lg shadow-lg py-1 min-w-[180px] z-[9999]"
+          style={{ top: position.top, right: position.right }}
+        >
           {actions.map((action, i) => (
             <button
               key={i}
               onClick={action.onClick}
               className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-bitcoin-orange transition-colors flex items-center gap-2"
             >
-              {action.icon && (
-                <span className="w-5 text-center">{action.icon}</span>
-              )}
+              {action.icon && <span className="w-5 text-center">{action.icon}</span>}
               {action.label}
             </button>
           ))}
         </div>
       )}
 
-      {/* Raw data panel */}
-      {showRaw && (
-        <div className="absolute right-0 top-full mt-1 z-50 bg-white border border-gray-200 rounded-lg shadow-lg w-[400px] max-w-[90vw]">
+      {/* Raw data panel — fixed positioning */}
+      {showRaw && position && (
+        <div
+          className="fixed bg-white border border-gray-200 rounded-lg shadow-lg w-[400px] max-w-[90vw] z-[9999]"
+          style={{ top: position.top, right: position.right }}
+        >
           <div className="flex items-center justify-between px-4 py-2 border-b border-gray-100">
             <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
               Raw Event{eventKind ? ` (kind ${eventKind})` : ""}

--- a/src/pages/committees.tsx
+++ b/src/pages/committees.tsx
@@ -1,34 +1,246 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import Head from "next/head";
 import { config } from "@/config";
+import { isWhitelisted } from "@/config";
+import { useNostr } from "@/contexts/NostrContext";
+import {
+  Committee,
+  CommitteeMember,
+  CommitteeOpening,
+  fetchCommittees,
+  fetchMembersForAllCommittees,
+  fetchOpeningsForAllCommittees,
+  buildDeleteEvent,
+  publishDelete,
+} from "@/utils/committeeEvents";
+import CommitteeFormModal from "@/components/CommitteeFormModal";
+import CommitteeMemberFormModal from "@/components/CommitteeMemberFormModal";
+import CommitteeOpeningFormModal from "@/components/CommitteeOpeningFormModal";
+import EventActions from "@/components/EventActions";
+import ReactMarkdown from "react-markdown";
+import { logger } from "@/utils/logger";
 
-interface Committee {
+// UI-facing committee shape (matches the existing rendering code)
+interface UICommittee {
+  id: string;
+  coordinate: string;
   name: string;
   description: string;
-  chair: string;
-  members: string[];
-  openPositions: string[];
-  meetingSchedule: string;
+  chair?: { name: string; email?: string; phone?: string };
+  viceChair?: { name: string; email?: string; phone?: string };
+  members: Array<{ name: string; email?: string; phone?: string }>;
+  openings: number;
+  meetingSchedule?: string;
+  image?: string;
+  rawCommittee: Committee;
+  rawMembers: CommitteeMember[];
+  rawOpenings: CommitteeOpening[];
+}
+
+function memberToContact(m: CommitteeMember): { name: string; email?: string; phone?: string } {
+  return { name: m.name, email: m.email, phone: m.phone };
+}
+
+function isRole(member: CommitteeMember, role: string): boolean {
+  const m = member.role.toLowerCase().replace(/[-_\s]+/g, "");
+  const r = role.toLowerCase().replace(/[-_\s]+/g, "");
+  return m === r;
+}
+
+function buildUICommittee(committee: Committee, members: CommitteeMember[], openings: CommitteeOpening[]): UICommittee {
+  const chair = members.find((m) => isRole(m, "chair"));
+  const viceChair = members.find((m) => isRole(m, "vice-chair"));
+  const regularMembers = members.filter((m) => !isRole(m, "chair") && !isRole(m, "vice-chair"));
+
+  return {
+    id: committee.id,
+    coordinate: committee.coordinate,
+    name: committee.title,
+    description: committee.description,
+    chair: chair ? memberToContact(chair) : undefined,
+    viceChair: viceChair ? memberToContact(viceChair) : undefined,
+    members: regularMembers.map(memberToContact),
+    openings: committee.openings,
+    meetingSchedule: committee.meetingSchedule,
+    image: committee.image,
+    rawCommittee: committee,
+    rawMembers: members,
+    rawOpenings: openings,
+  };
 }
 
 export default function CommitteesPage() {
-  const committees: Committee[] = config.pages.committees?.data ?? [];
-  const [selectedCommittee, setSelectedCommittee] = useState<Committee | null>(null);
+  const [committees, setCommittees] = useState<Committee[]>([]);
+  const [membersMap, setMembersMap] = useState<Map<string, CommitteeMember[]>>(new Map());
+  const [openingsMap, setOpeningsMap] = useState<Map<string, CommitteeOpening[]>>(new Map());
+  const [loading, setLoading] = useState(true);
+  const [selectedCommittee, setSelectedCommittee] = useState<UICommittee | null>(null);
   const [showApplicationForm, setShowApplicationForm] = useState(false);
+  const [showAddCommittee, setShowAddCommittee] = useState(false);
+  const [editCommittee, setEditCommittee] = useState<Committee | null>(null);
+  const [showAddMember, setShowAddMember] = useState(false);
+  const [memberTargetCommittee, setMemberTargetCommittee] = useState<Committee | null>(null);
+  const [editMember, setEditMember] = useState<CommitteeMember | null>(null);
+  const [showAddOpening, setShowAddOpening] = useState(false);
+  const [editOpening, setEditOpening] = useState<CommitteeOpening | null>(null);
+  const [expandedOpenings, setExpandedOpenings] = useState<Set<string>>(new Set());
+  const [expandedMembers, setExpandedMembers] = useState<Set<string>>(new Set());
+  const { user, hasExtension } = useNostr();
 
-  const totalOpenings = committees.reduce(
-    (sum, c) => sum + c.openPositions.length,
-    0,
+  // Sign an event using the NIP-07 extension or Nostr context
+  const signEvent = async (event: { kind: number; content: string; tags: string[][]; created_at: number }): Promise<Record<string, unknown>> => {
+    if (window.nostr) {
+      const pk = await window.nostr.getPublicKey();
+      return await window.nostr.signEvent({ ...event, pubkey: pk });
+    }
+    throw new Error("No signing method available");
+  };
+
+  // Show admin controls if user has a whitelisted pubkey OR if NIP-07 extension is present
+  // (extension users can sign events — the whitelist is checked server-side on publish)
+  const isAdmin = (user && isWhitelisted(user.pubkey)) || hasExtension;
+
+  const loadAll = useCallback(async () => {
+    setLoading(true);
+    try {
+      const fetchedCommittees = await fetchCommittees();
+      setCommittees(fetchedCommittees);
+      const members = await fetchMembersForAllCommittees(fetchedCommittees);
+      setMembersMap(members);
+      const openings = await fetchOpeningsForAllCommittees(fetchedCommittees);
+      setOpeningsMap(openings);
+    } catch (err) {
+      logger.warn("Failed to load committee data:", err);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { loadAll(); }, [loadAll]);
+
+  const uiCommittees = committees.map((c) =>
+    buildUICommittee(c, membersMap.get(c.coordinate) || [], openingsMap.get(c.coordinate) || [])
   );
+  const totalOpenings = uiCommittees.reduce((sum, c) => sum + c.rawOpenings.length, 0);
+  const totalMembers = uiCommittees.reduce((sum, c) => sum + c.rawMembers.length, 0);
+
+  const handleDeleteCommittee = useCallback(async (committee: Committee) => {
+    if (!user || !committee.rawEvent) return;
+    const unsignedDelete = buildDeleteEvent({
+      eventId: committee.id,
+      eventKind: 30068,
+      reason: "Deleted by author",
+    });
+    const signedDelete = await signEvent(unsignedDelete as { kind: number; content: string; tags: string[][]; created_at: number });
+    await publishDelete(signedDelete);
+    // Optimistically remove
+    setCommittees((prev) => prev.filter((c) => c.id !== committee.id));
+  }, [user, signEvent]);
+
+  const handleDeleteMember = useCallback(async (member: CommitteeMember) => {
+    if (!user || !member.rawEvent) return;
+    const unsignedDelete = buildDeleteEvent({
+      eventId: member.id,
+      eventKind: 39068,
+      reason: "Deleted by author",
+    });
+    const signedDelete = await signEvent(unsignedDelete as { kind: number; content: string; tags: string[][]; created_at: number });
+    await publishDelete(signedDelete);
+    // Optimistically remove
+    setMembersMap((prev) => {
+      const updated = new Map(prev);
+      const members = (updated.get(member.committeeCoordinate) || []).filter((m) => m.id !== member.id);
+      updated.set(member.committeeCoordinate, members);
+      return updated;
+    });
+  }, [user, signEvent]);
+
+  const handleEditCommittee = useCallback((committee: Committee) => {
+    setEditCommittee(committee);
+    setShowAddCommittee(true);
+  }, []);
+
+  const handleEditMember = useCallback((member: CommitteeMember) => {
+    setEditMember(member);
+    setShowAddMember(true);
+  }, []);
+
+  const handleDeleteOpening = useCallback(async (opening: CommitteeOpening) => {
+    if (!user || !opening.rawEvent) return;
+    const unsignedDelete = buildDeleteEvent({
+      eventId: opening.id,
+      eventKind: 39069,
+      reason: "Deleted by author",
+    });
+    const signedDelete = await signEvent(unsignedDelete as { kind: number; content: string; tags: string[][]; created_at: number });
+    await publishDelete(signedDelete);
+    // Optimistically remove
+    setOpeningsMap((prev) => {
+      const updated = new Map(prev);
+      const openings = (updated.get(opening.committeeCoordinate) || []).filter((o) => o.id !== opening.id);
+      updated.set(opening.committeeCoordinate, openings);
+      return updated;
+    });
+    if (selectedCommittee) {
+      setSelectedCommittee({
+        ...selectedCommittee,
+        rawOpenings: selectedCommittee.rawOpenings.filter((o) => o.id !== opening.id),
+      });
+    }
+  }, [user, signEvent, selectedCommittee]);
+
+  const handleEditOpening = useCallback((opening: CommitteeOpening) => {
+    setEditOpening(opening);
+    setShowAddOpening(true);
+  }, []);
+
+  const handleOpeningDone = useCallback(async () => {
+    setShowAddOpening(false);
+    setEditOpening(null);
+    const fetchedCommittees = await fetchCommittees();
+    setCommittees(fetchedCommittees);
+    const members = await fetchMembersForAllCommittees(fetchedCommittees);
+    setMembersMap(members);
+    const openings = await fetchOpeningsForAllCommittees(fetchedCommittees);
+    setOpeningsMap(openings);
+    if (selectedCommittee) {
+      const coord = selectedCommittee.coordinate;
+      const updated = fetchedCommittees.find((c) => c.coordinate === coord);
+      if (updated) {
+        setSelectedCommittee(buildUICommittee(updated, members.get(coord) || [], openings.get(coord) || []));
+      }
+    }
+  }, [selectedCommittee]);
+
+  const handleCommitteeDone = useCallback(() => {
+    setShowAddCommittee(false);
+    setEditCommittee(null);
+    loadAll();
+  }, [loadAll]);
+
+  const handleMemberDone = useCallback(async () => {
+    setShowAddMember(false);
+    setEditMember(null);
+    const fetchedCommittees = await fetchCommittees();
+    setCommittees(fetchedCommittees);
+    const members = await fetchMembersForAllCommittees(fetchedCommittees);
+    setMembersMap(members);
+    const openings = await fetchOpeningsForAllCommittees(fetchedCommittees);
+    setOpeningsMap(openings);
+    // Refresh selected committee with fresh data
+    if (selectedCommittee) {
+      const coord = selectedCommittee.coordinate;
+      const updated = fetchedCommittees.find((c) => c.coordinate === coord);
+      if (updated) {
+        setSelectedCommittee(buildUICommittee(updated, members.get(coord) || [], openings.get(coord) || []));
+      }
+    }
+  }, [selectedCommittee]);
 
   return (
     <>
       <Head>
-        <title>{config.pages.committees?.meta?.title ?? "Committees"}</title>
-        <meta
-          name="description"
-          content={config.pages.committees?.meta?.description ?? "Committees page"}
-        />
+        <title>{config.pages.committees.meta.title}</title>
+        <meta name="description" content={config.pages.committees.meta.description} />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
@@ -40,117 +252,130 @@ export default function CommitteesPage() {
             Committees
           </h1>
           <p className="text-lg text-gray-600 max-w-2xl mx-auto">
-            Get involved by joining one of our committees. We have positions
-            open for dedicated community members who want to make a difference.
+            Get involved in the Ray County bitcoin-orange Party by joining one of our committees.
+            We have positions open for dedicated bitcoin-oranges who want to make a difference.
           </p>
         </div>
 
-        {committees.length === 0 ? (
-          <div className="text-center py-16">
-            <div className="text-6xl mb-4">📋</div>
-            <h2 className="text-2xl font-bold text-gray-800 mb-2">
-              No Committees Configured
-            </h2>
-            <p className="text-gray-600 max-w-md mx-auto">
-              Committees haven&apos;t been set up yet. Check back later or
-              contact an organizer to learn about getting involved.
+        {/* Statistics */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
+          <div className="bg-white border border-gray-200 rounded-lg p-6 text-center shadow-sm">
+            <div className="text-3xl font-bold bitcoin-orange mb-2">
+              {uiCommittees.length}
+            </div>
+            <div className="text-gray-600">Active Committees</div>
+          </div>
+          <div className="bg-white border border-gray-200 rounded-lg p-6 text-center shadow-sm">
+            <div className="text-3xl font-bold green-600 mb-2">
+              {totalOpenings}
+            </div>
+            <div className="text-gray-600">Open Positions</div>
+          </div>
+          <div className="bg-white border border-gray-200 rounded-lg p-6 text-center shadow-sm">
+            <div className="text-3xl font-bold bitcoin-orange mb-2">
+              {totalMembers}
+            </div>
+            <div className="text-gray-600">Members</div>
+          </div>
+        </div>
+
+        {/* Admin: Add Committee + Apply buttons */}
+        <div className="text-center mb-12 flex justify-center gap-4 flex-wrap">
+          <button
+            onClick={() => setShowApplicationForm(true)}
+            className="px-8 py-3 bg-bitcoin-orange text-white rounded-lg font-semibold hover:bg-bitcoin-orange-hover transition-colors"
+          >
+            Apply to Join a Committee
+          </button>
+          {isAdmin && (
+            <button
+              data-testid="add-committee-btn"
+              onClick={() => { setEditCommittee(null); setShowAddCommittee(true); }}
+              className="px-8 py-3 border-2 border-bitcoin-orange text-bitcoin-orange rounded-lg font-semibold hover:bg-bitcoin-orange hover:text-white transition-colors"
+            >
+              + Create Committee
+            </button>
+          )}
+        </div>
+
+        {/* Loading State */}
+        {loading && (
+          <div className="mb-8 text-center" data-testid="committees-loading">
+            <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 max-w-md mx-auto">
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-bitcoin-orange mx-auto mb-4"></div>
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">Loading Committees</h3>
+              <p className="text-gray-600">Connecting to Nostr...</p>
+            </div>
+          </div>
+        )}
+
+        {/* Empty State */}
+        {!loading && uiCommittees.length === 0 && (
+          <div className="bg-gray-50 border border-gray-200 rounded-lg p-12 text-center" data-testid="committees-empty">
+            <span className="text-6xl block mb-4">🏛️</span>
+            <h3 className="text-xl font-bold text-gray-800 mb-2">No Committees Yet</h3>
+            <p className="text-gray-600">
+              {isAdmin
+                ? "Click \"Create Committee\" above to add the first committee."
+                : "Committees will appear here once they are created. Check back soon!"}
             </p>
           </div>
-        ) : (
-          <>
-            {/* Statistics */}
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
-              <div className="bg-white border border-gray-200 rounded-lg p-6 text-center shadow-sm">
-                <div className="text-3xl font-bold bitcoin-orange mb-2">
-                  {committees.length}
-                </div>
-                <div className="text-gray-600">Active Committees</div>
-              </div>
-              <div className="bg-white border border-gray-200 rounded-lg p-6 text-center shadow-sm">
-                <div className="text-3xl font-bold green-600 mb-2">
-                  {totalOpenings}
-                </div>
-                <div className="text-gray-600">Open Positions</div>
-              </div>
-              <div className="bg-white border border-gray-200 rounded-lg p-6 text-center shadow-sm">
-                <div className="text-3xl font-bold bitcoin-orange mb-2">
-                  Join Us
-                </div>
-                <div className="text-gray-600">Make a Difference</div>
-              </div>
-            </div>
+        )}
 
-            {/* Apply Button */}
-            <div className="text-center mb-12">
-              <button
-                onClick={() => setShowApplicationForm(true)}
-                className="px-8 py-3 bg-bitcoin-orange text-white rounded-lg font-semibold hover:bg-bitcoin-orange-hover transition-colors"
+        {/* Committee Cards */}
+        {!loading && uiCommittees.length > 0 && (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {uiCommittees.map((committee) => (
+              <div
+                key={committee.id}
+                data-testid={`committee-card-${committee.rawCommittee.dTag}`}
+                className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+                onClick={() => setSelectedCommittee(committee)}
               >
-                Apply to Join a Committee
-              </button>
-            </div>
-
-            {/* Committee Cards */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {committees.map((committee, index) => (
-                <div
-                  key={index}
-                  className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm hover:shadow-md transition-shadow cursor-pointer"
-                  onClick={() => setSelectedCommittee(committee)}
-                >
-                  <div className="flex items-start justify-between mb-4">
-                    <h3 className="text-xl font-bold font-archivo-black bitcoin-orange">
-                      {committee.name}
-                    </h3>
-                    {committee.openPositions.length > 0 && (
+                <div className="flex items-start justify-between mb-4">
+                  <h3
+                    className="text-xl font-bold font-archivo-black bitcoin-orange cursor-pointer hover:underline"
+                    onClick={() => setSelectedCommittee(committee)}
+                  >
+                    {committee.name}
+                  </h3>
+                  <div className="flex items-center gap-1">
+                    {committee.rawOpenings.length > 0 && (
                       <span className="bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">
-                        {committee.openPositions.length} Open
-                        {committee.openPositions.length > 1 ? "ings" : "ing"}
+                        {committee.rawOpenings.length} Open{committee.rawOpenings.length > 1 ? 'ings' : 'ing'}
                       </span>
                     )}
-                  </div>
-                  <p className="text-gray-600 mb-4 text-sm">
-                    {committee.description}
-                  </p>
-                  <div className="text-sm text-gray-500">
-                    <div className="flex items-center gap-2">
-                      <svg
-                        className="w-4 h-4"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                    {isAdmin && committee.rawCommittee.rawEvent && (
+                      <div onClick={(e) => e.stopPropagation()}>
+                        <EventActions
+                          event={committee.rawCommittee.rawEvent}
+                          onEdit={() => handleEditCommittee(committee.rawCommittee)}
+                          onDelete={() => handleDeleteCommittee(committee.rawCommittee)}
                         />
-                      </svg>
-                      {committee.meetingSchedule || "Schedule TBD"}
-                    </div>
-                    <div className="flex items-center gap-2 mt-1">
-                      <svg
-                        className="w-4 h-4"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-                        />
-                      </svg>
-                      {committee.members.length} Member
-                      {committee.members.length !== 1 ? "s" : ""}
-                    </div>
+                      </div>
+                    )}
                   </div>
                 </div>
-              ))}
-            </div>
-          </>
+                <p className="text-gray-600 mb-4 text-sm cursor-pointer" onClick={() => setSelectedCommittee(committee)}>
+                  {committee.description}
+                </p>
+                <div className="text-sm text-gray-500">
+                  <div className="flex items-center gap-2">
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                    </svg>
+                    {committee.meetingSchedule || "Schedule TBD"}
+                  </div>
+                  <div className="flex items-center gap-2 mt-1">
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+                    </svg>
+                    {committee.rawMembers.length} Member{committee.rawMembers.length !== 1 ? 's' : ''}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
         )}
       </div>
 
@@ -164,12 +389,9 @@ export default function CommitteesPage() {
                   <h2 className="text-2xl font-bold font-archivo-black bitcoin-orange mb-2">
                     {selectedCommittee.name}
                   </h2>
-                  {selectedCommittee.openPositions.length > 0 && (
+                  {selectedCommittee.rawOpenings.length > 0 && (
                     <span className="inline-block bg-green-100 text-green-800 text-sm font-medium px-3 py-1 rounded">
-                      {selectedCommittee.openPositions.length} Open Position
-                      {selectedCommittee.openPositions.length > 1
-                        ? "s"
-                        : ""}
+                      {selectedCommittee.rawOpenings.length} Open Position{selectedCommittee.rawOpenings.length > 1 ? 's' : ''}
                     </span>
                   )}
                 </div>
@@ -188,18 +410,8 @@ export default function CommitteesPage() {
               {selectedCommittee.meetingSchedule && (
                 <div className="bg-gray-50 rounded-lg p-4 mb-6">
                   <div className="flex items-center gap-2 text-sm">
-                    <svg
-                      className="w-5 h-5 bitcoin-orange"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                      />
+                    <svg className="w-5 h-5 bitcoin-orange" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                     </svg>
                     <span className="font-medium">Meeting Schedule:</span>
                     <span>{selectedCommittee.meetingSchedule}</span>
@@ -208,77 +420,273 @@ export default function CommitteesPage() {
               )}
 
               {/* Leadership */}
-              {selectedCommittee.chair && (
+              {(selectedCommittee.chair || selectedCommittee.viceChair) && (
                 <div className="mb-6">
-                  <h3 className="text-lg font-bold mb-3 font-archivo-black">
-                    Leadership
-                  </h3>
+                  <h3 className="text-lg font-bold mb-3 font-archivo-black">Leadership</h3>
                   <div className="space-y-2">
-                    <div className="flex items-center gap-3 bg-gray-50 rounded-lg p-3">
-                      <div className="w-10 h-10 bg-bitcoin-orange rounded-full flex items-center justify-center text-white font-bold">
-                        C
-                      </div>
-                      <div>
-                        <div className="font-medium">
-                          {selectedCommittee.chair}
+                    {selectedCommittee.chair && (() => {
+                      const chairMember = selectedCommittee.rawMembers.find((m) => m.role === "chair");
+                      const chairId = chairMember?.id || "chair";
+                      const chairExpanded = expandedMembers.has(chairId);
+                      const hasChairContact = !!(selectedCommittee.chair.email || selectedCommittee.chair.phone);
+                      return (
+                        <div className="bg-gray-50 rounded-lg p-3">
+                          <div className="flex items-center gap-3">
+                            <div className="w-10 h-10 bg-bitcoin-orange rounded-full flex items-center justify-center text-white font-bold flex-shrink-0">
+                              C
+                            </div>
+                            <div className="flex-1 min-w-0">
+                              <div className="font-medium">{selectedCommittee.chair.name}</div>
+                              <div className="text-sm text-gray-500">Chair</div>
+                            </div>
+                            {hasChairContact && (
+                              <button
+                                onClick={() => setExpandedMembers((prev) => {
+                                  const s = new Set(prev);
+                                  if (s.has(chairId)) s.delete(chairId);
+                                  else s.add(chairId);
+                                  return s;
+                                })}
+                                className="text-sm px-3 py-1 border border-gray-300 rounded text-gray-700 hover:bg-gray-100 transition-colors font-medium flex-shrink-0"
+                              >
+                                {chairExpanded ? "Hide" : "Contact"}
+                              </button>
+                            )}
+                            {isAdmin && chairMember?.rawEvent && (
+                              <EventActions
+                                event={chairMember.rawEvent}
+                                onEdit={() => handleEditMember(chairMember)}
+                                onDelete={() => handleDeleteMember(chairMember)}
+                              />
+                            )}
+                          </div>
+                          {chairExpanded && hasChairContact && (
+                            <div className="mt-2 pl-[52px] text-sm">
+                              {selectedCommittee.chair.email && (
+                                <a href={`mailto:${selectedCommittee.chair.email}`} className="text-bitcoin-orange hover:underline mr-3">
+                                  {selectedCommittee.chair.email}
+                                </a>
+                              )}
+                              {selectedCommittee.chair.phone && (
+                                <a href={`tel:${selectedCommittee.chair.phone}`} className="text-gray-600">
+                                  {selectedCommittee.chair.phone}
+                                </a>
+                              )}
+                            </div>
+                          )}
                         </div>
-                        <div className="text-sm text-gray-500">Chair</div>
-                      </div>
-                    </div>
+                      );
+                    })()}
+                    {selectedCommittee.viceChair && (() => {
+                      const vcMember = selectedCommittee.rawMembers.find((m) => m.role === "vice-chair");
+                      const vcId = vcMember?.id || "vice-chair";
+                      const vcExpanded = expandedMembers.has(vcId);
+                      const hasVcContact = !!(selectedCommittee.viceChair.email || selectedCommittee.viceChair.phone);
+                      return (
+                        <div className="bg-gray-50 rounded-lg p-3">
+                          <div className="flex items-center gap-3">
+                            <div className="w-10 h-10 bg-gray-600 rounded-full flex items-center justify-center text-white font-bold flex-shrink-0">
+                              VC
+                            </div>
+                            <div className="flex-1 min-w-0">
+                              <div className="font-medium">{selectedCommittee.viceChair.name}</div>
+                              <div className="text-sm text-gray-500">Vice Chair</div>
+                            </div>
+                            {hasVcContact && (
+                              <button
+                                onClick={() => setExpandedMembers((prev) => {
+                                  const s = new Set(prev);
+                                  if (s.has(vcId)) s.delete(vcId);
+                                  else s.add(vcId);
+                                  return s;
+                                })}
+                                className="text-sm px-3 py-1 border border-gray-300 rounded text-gray-700 hover:bg-gray-100 transition-colors font-medium flex-shrink-0"
+                              >
+                                {vcExpanded ? "Hide" : "Contact"}
+                              </button>
+                            )}
+                            {isAdmin && vcMember?.rawEvent && (
+                              <EventActions
+                                event={vcMember.rawEvent}
+                                onEdit={() => handleEditMember(vcMember)}
+                                onDelete={() => handleDeleteMember(vcMember)}
+                              />
+                            )}
+                          </div>
+                          {vcExpanded && hasVcContact && (
+                            <div className="mt-2 pl-[52px] text-sm">
+                              {selectedCommittee.viceChair.email && (
+                                <a href={`mailto:${selectedCommittee.viceChair.email}`} className="text-bitcoin-orange hover:underline mr-3">
+                                  {selectedCommittee.viceChair.email}
+                                </a>
+                              )}
+                              {selectedCommittee.viceChair.phone && (
+                                <a href={`tel:${selectedCommittee.viceChair.phone}`} className="text-gray-600">
+                                  {selectedCommittee.viceChair.phone}
+                                </a>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })()}
                   </div>
                 </div>
               )}
 
               {/* Members */}
               <div className="mb-6">
-                <h3 className="text-lg font-bold mb-3 font-archivo-black">
-                  Members
-                </h3>
-                <div className="space-y-2">
-                  {selectedCommittee.members.map((member, memberIndex) => (
-                    <div
-                      key={memberIndex}
-                      className="flex items-center gap-3 bg-gray-50 rounded-lg p-3"
+                <div className="flex items-center justify-between mb-3">
+                  <h3 className="text-lg font-bold font-archivo-black">Members</h3>
+                  {isAdmin && (
+                    <button
+                      data-testid="add-member-btn"
+                      onClick={() => {
+                        setMemberTargetCommittee(selectedCommittee.rawCommittee);
+                        setEditMember(null);
+                        setShowAddMember(true);
+                      }}
+                      className="text-sm px-3 py-1 bg-bitcoin-orange text-white rounded hover:bg-bitcoin-orange-hover transition-colors font-semibold"
                     >
-                      <div className="w-10 h-10 bg-gray-200 rounded-full flex items-center justify-center text-gray-600 font-bold">
-                        {member.charAt(0)}
-                      </div>
-                      <div className="flex-1">
-                        <div className="font-medium">{member}</div>
-                      </div>
-                    </div>
-                  ))}
+                      + Add Member
+                    </button>
+                  )}
                 </div>
+                {selectedCommittee.members.length > 0 ? (
+                  <div className="space-y-2">
+                    {selectedCommittee.members.map((member, index) => {
+                      const rawMember = selectedCommittee.rawMembers.filter((m) => !isRole(m, "chair") && !isRole(m, "vice-chair"))[index];
+                      const memberId = rawMember?.id || `member-${index}`;
+                      const isExpanded = expandedMembers.has(memberId);
+                      const hasContact = !!(member.email || member.phone);
+                      return (
+                        <div
+                          key={index}
+                          className="bg-gray-50 rounded-lg p-3"
+                        >
+                          <div className="flex items-center gap-3">
+                            <div className="w-10 h-10 bg-gray-200 rounded-full flex items-center justify-center text-gray-600 font-bold flex-shrink-0">
+                              {member.name.charAt(0)}
+                            </div>
+                            <div className="flex-1 min-w-0">
+                              <div className="font-medium">{member.name}</div>
+                              {rawMember && (
+                                <div className="text-sm text-gray-500">{rawMember.role}</div>
+                              )}
+                            </div>
+                            {hasContact && (
+                              <button
+                                onClick={() => setExpandedMembers((prev) => {
+                                  const s = new Set(prev);
+                                  if (s.has(memberId)) s.delete(memberId);
+                                  else s.add(memberId);
+                                  return s;
+                                })}
+                                className="text-sm px-3 py-1 border border-gray-300 rounded text-gray-700 hover:bg-gray-100 transition-colors font-medium flex-shrink-0"
+                              >
+                                {isExpanded ? "Hide" : "Contact"}
+                              </button>
+                            )}
+                            {isAdmin && rawMember?.rawEvent && (
+                              <EventActions
+                                event={rawMember.rawEvent}
+                                onEdit={() => handleEditMember(rawMember)}
+                                onDelete={() => handleDeleteMember(rawMember)}
+                              />
+                            )}
+                          </div>
+                          {isExpanded && hasContact && (
+                            <div className="mt-2 pl-[52px] text-sm">
+                              {member.email && (
+                                <a href={`mailto:${member.email}`} className="text-bitcoin-orange hover:underline mr-3">
+                                  {member.email}
+                                </a>
+                              )}
+                              {member.phone && (
+                                <a href={`tel:${member.phone}`} className="text-gray-600">
+                                  {member.phone}
+                                </a>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className="text-gray-500 text-sm">No members yet.</p>
+                )}
               </div>
 
               {/* Open Positions */}
-              {selectedCommittee.openPositions.length > 0 && (
-                <div className="mb-6">
-                  <h3 className="text-lg font-bold mb-3 font-archivo-black">
-                    Open Positions
-                  </h3>
-                  <div className="space-y-2">
-                    {selectedCommittee.openPositions.map(
-                      (position, posIndex) => (
-                        <div
-                          key={posIndex}
-                          className="flex items-center gap-3 bg-green-50 rounded-lg p-3"
-                        >
-                          <div className="w-10 h-10 bg-green-200 rounded-full flex items-center justify-center text-green-700 font-bold">
-                            +
-                          </div>
-                          <div className="font-medium text-green-800">
-                            {position}
-                          </div>
-                        </div>
-                      ),
-                    )}
-                  </div>
+              <div className="mb-6">
+                <div className="flex items-center justify-between mb-3">
+                  <h3 className="text-lg font-bold font-archivo-black">Open Positions</h3>
+                  {isAdmin && (
+                    <button
+                      onClick={() => {
+                        setEditOpening(null);
+                        setShowAddOpening(true);
+                      }}
+                      className="text-sm px-3 py-1 bg-bitcoin-orange text-white rounded hover:bg-bitcoin-orange-hover transition-colors font-semibold"
+                    >
+                      + Add Opening
+                    </button>
+                  )}
                 </div>
-              )}
+                {selectedCommittee.rawOpenings.length > 0 ? (
+                  <div className="space-y-2">
+                    {selectedCommittee.rawOpenings.map((opening) => (
+                      <div
+                        key={opening.id}
+                        className="flex items-start gap-3 bg-gray-50 rounded-lg p-3"
+                      >
+                        <div className="w-10 h-10 bg-green-100 rounded-full flex items-center justify-center text-green-700 font-bold flex-shrink-0">
+                          OP
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <div className="font-medium">{opening.title}</div>
+                          {opening.description && (
+                            <div className="text-sm text-gray-600 mt-1">
+                              {expandedOpenings.has(opening.id) ? (
+                                <div className="prose prose-sm max-w-none">
+                                  <ReactMarkdown>{opening.description}</ReactMarkdown>
+                                  <button
+                                    onClick={() => setExpandedOpenings((prev) => { const s = new Set(prev); s.delete(opening.id); return s; })}
+                                    className="text-bitcoin-orange hover:underline text-xs font-medium mt-1"
+                                  >
+                                    Show less
+                                  </button>
+                                </div>
+                              ) : (
+                                <div
+                                  onClick={() => setExpandedOpenings((prev) => new Set(prev).add(opening.id))}
+                                  className="line-clamp-2 cursor-pointer"
+                                >
+                                  <ReactMarkdown>{opening.description}</ReactMarkdown>
+                                  <span className="text-bitcoin-orange hover:underline text-xs font-medium">Show more</span>
+                                </div>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                        {isAdmin && opening.rawEvent && (
+                          <EventActions
+                            event={opening.rawEvent}
+                            onEdit={() => handleEditOpening(opening)}
+                            onDelete={() => handleDeleteOpening(opening)}
+                          />
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-gray-500 text-sm">No open positions.</p>
+                )}
+              </div>
 
               {/* Apply Button */}
-              {selectedCommittee.openPositions.length > 0 && (
+              {selectedCommittee.rawOpenings.length > 0 && (
                 <button
                   onClick={() => {
                     setSelectedCommittee(null);
@@ -316,38 +724,24 @@ export default function CommitteesPage() {
                   e.preventDefault();
                   const formData = new FormData(e.currentTarget);
                   const data = {
-                    name: formData.get("name") as string,
-                    email: formData.get("email") as string,
-                    phone: formData.get("phone") as string,
-                    committee: formData.get("committee") as string,
-                    message: formData.get("message") as string,
+                    name: formData.get('name') as string,
+                    email: formData.get('email') as string,
+                    phone: formData.get('phone') as string,
+                    committee: formData.get('committee') as string,
+                    message: formData.get('message') as string,
                   };
 
-                  // Save to localStorage
-                  const existingApps = JSON.parse(
-                    localStorage.getItem("committee-applications") || "[]",
-                  );
-                  existingApps.push({
-                    ...data,
-                    submittedAt: new Date().toISOString(),
-                  });
-                  localStorage.setItem(
-                    "committee-applications",
-                    JSON.stringify(existingApps),
-                  );
+                  const existingApps = JSON.parse(localStorage.getItem('committee-applications') || '[]');
+                  existingApps.push({ ...data, submittedAt: new Date().toISOString() });
+                  localStorage.setItem('committee-applications', JSON.stringify(existingApps));
 
-                  alert(
-                    "Thank you for your interest! Your application has been submitted.",
-                  );
+                  alert('Thank you for your interest! Your application has been submitted.');
                   setShowApplicationForm(false);
                 }}
                 className="space-y-4"
               >
                 <div>
-                  <label
-                    htmlFor="name"
-                    className="block text-sm font-medium text-gray-700 mb-1"
-                  >
+                  <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-1">
                     Full Name *
                   </label>
                   <input
@@ -360,10 +754,7 @@ export default function CommitteesPage() {
                 </div>
 
                 <div>
-                  <label
-                    htmlFor="email"
-                    className="block text-sm font-medium text-gray-700 mb-1"
-                  >
+                  <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
                     Email Address *
                   </label>
                   <input
@@ -376,10 +767,7 @@ export default function CommitteesPage() {
                 </div>
 
                 <div>
-                  <label
-                    htmlFor="phone"
-                    className="block text-sm font-medium text-gray-700 mb-1"
-                  >
+                  <label htmlFor="phone" className="block text-sm font-medium text-gray-700 mb-1">
                     Phone Number
                   </label>
                   <input
@@ -391,10 +779,7 @@ export default function CommitteesPage() {
                 </div>
 
                 <div>
-                  <label
-                    htmlFor="committee"
-                    className="block text-sm font-medium text-gray-700 mb-1"
-                  >
+                  <label htmlFor="committee" className="block text-sm font-medium text-gray-700 mb-1">
                     Committee of Interest *
                   </label>
                   <select
@@ -404,8 +789,8 @@ export default function CommitteesPage() {
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-bitcoin-orange"
                   >
                     <option value="">Select a committee</option>
-                    {committees.map((committee, index) => (
-                      <option key={index} value={committee.name}>
+                    {uiCommittees.map((committee) => (
+                      <option key={committee.id} value={committee.rawCommittee.dTag}>
                         {committee.name}
                       </option>
                     ))}
@@ -413,10 +798,7 @@ export default function CommitteesPage() {
                 </div>
 
                 <div>
-                  <label
-                    htmlFor="message"
-                    className="block text-sm font-medium text-gray-700 mb-1"
-                  >
+                  <label htmlFor="message" className="block text-sm font-medium text-gray-700 mb-1">
                     Why do you want to join? *
                   </label>
                   <textarea
@@ -438,6 +820,37 @@ export default function CommitteesPage() {
             </div>
           </div>
         </div>
+      )}
+
+      {/* Modals */}
+      {showAddCommittee && (
+        <CommitteeFormModal
+          editCommittee={editCommittee}
+          onDone={handleCommitteeDone}
+          onCancel={() => { setShowAddCommittee(false); setEditCommittee(null); }}
+          pubkey={user?.pubkey}
+          signEvent={signEvent}
+        />
+      )}
+      {showAddMember && memberTargetCommittee && (
+        <CommitteeMemberFormModal
+          committeeCoordinate={memberTargetCommittee.coordinate}
+          editMember={editMember}
+          onDone={handleMemberDone}
+          onCancel={() => { setShowAddMember(false); setEditMember(null); }}
+          pubkey={user?.pubkey}
+          signEvent={signEvent}
+        />
+      )}
+      {showAddOpening && selectedCommittee && (
+        <CommitteeOpeningFormModal
+          committeeCoordinate={selectedCommittee.coordinate}
+          editOpening={editOpening}
+          onDone={handleOpeningDone}
+          onCancel={() => { setShowAddOpening(false); setEditOpening(null); }}
+          pubkey={user?.pubkey}
+          signEvent={signEvent}
+        />
       )}
     </>
   );

--- a/src/pages/education.tsx
+++ b/src/pages/education.tsx
@@ -22,6 +22,8 @@ import {
   DetectedContent,
 } from "@/utils/pinboardEvents";
 import EventActions from "@/components/EventActions";
+import { logger } from "@/utils/logger";
+import { useNostr } from "@/contexts/NostrContext";
 
 function getYouTubeId(url: string): string | null {
   const match = url.match(
@@ -46,6 +48,16 @@ function getSpotifyEpisodeId(url: string): string | null {
 }
 
 export default function EducationPage() {
+  const { user, hasExtension } = useNostr();
+
+  // Sign an event using the NIP-07 extension
+  const signEvent = async (event: { kind: number; content: string; tags: string[][]; created_at: number }): Promise<Record<string, unknown>> => {
+    if (window.nostr) {
+      const pk = await window.nostr.getPublicKey();
+      return await window.nostr.signEvent({ ...event, pubkey: pk });
+    }
+    throw new Error("No signing method available");
+  };
   const [pinboards, setPinboards] = useState<Pinboard[]>([]);
   const [featuredPins, setFeaturedPins] = useState<Pin[]>([]);
   const [selectedBoard, setSelectedBoard] = useState<Pinboard | null>(null);
@@ -59,28 +71,25 @@ export default function EducationPage() {
   const [editPin, setEditPin] = useState<Pin | null>(null);
   const [sortBy, setSortBy] = useState<"date" | "title">("date");
 
-  useEffect(() => { loadAll(); }, []);
-
-  const loadAll = async () => {
-    setLoadingFeatured(true);
-    setLoadingBoards(true);
-    try {
-      const [boards, pins] = await Promise.all([fetchPinboards(), fetchFeaturedPins()]);
-      setPinboards(boards);
-      setFeaturedPins(pins);
-    } catch (err) {
-      console.warn("Failed to load education data:", err);
-    }
-    setLoadingFeatured(false);
-    setLoadingBoards(false);
-  };
+  useEffect(() => {
+    Promise.all([fetchFeaturedPins(), fetchPinboards()])
+      .then(([pins, boards]) => {
+        setFeaturedPins(pins.sort((a, b) => b.created_at - a.created_at));
+        setPinboards(boards);
+      })
+      .catch(() => {})
+      .finally(() => {
+        setLoadingFeatured(false);
+        setLoadingBoards(false);
+      });
+  }, []);
 
   const loadPins = useCallback(async (board: Pinboard) => {
     setLoadingPins(true);
     try {
       setBoardPins(await fetchPinsForBoard(board));
     } catch (err) {
-      console.warn("Failed to load pins:", err);
+      logger.warn("Failed to load pins:", err);
       setBoardPins([]);
     }
     setLoadingPins(false);
@@ -102,14 +111,17 @@ export default function EducationPage() {
     setShowAddPin(false);
     setEditPin(null);
     if (selectedBoard) loadPins(selectedBoard);
-    else loadAll();
+    // Re-fetch to pick up the new pin
+    fetchFeaturedPins().then((pins) => {
+      setFeaturedPins(pins.sort((a, b) => b.created_at - a.created_at));
+    }).catch(() => {});
+    fetchPinboards().then((boards) => setPinboards(boards)).catch(() => {});
   }, [selectedBoard, loadPins]);
 
   const handleDeletePin = useCallback(async (pin: Pin) => {
-    if (!window.nostr || !pin.rawEvent) return;
-    const pubkey = await window.nostr.getPublicKey();
+    if (!user || !pin.rawEvent) return;
     // Only allow deleting your own pins
-    if (pubkey !== pin.pubkey) return;
+    if (user.pubkey !== pin.pubkey) return;
 
     // Optimistically remove from local state
     const pinId = pin.id;
@@ -121,9 +133,9 @@ export default function EducationPage() {
       eventKind: 39067,
       reason: "Deleted by author",
     });
-    const signedDelete = await window.nostr.signEvent({ ...unsignedDelete, pubkey });
+    const signedDelete = await signEvent(unsignedDelete as { kind: number; content: string; tags: string[][]; created_at: number });
     await publishDelete(signedDelete);
-  }, []);
+  }, [user, signEvent]);
 
   const handleEditPin = useCallback((pin: Pin) => {
     setEditPin(pin);
@@ -140,11 +152,10 @@ export default function EducationPage() {
   });
 
   // Get the default board coordinate for adding pins.
-  // When a NIP-07 extension is present, always allow adding -- the pinboard
+  // When a NIP-07 extension is present, always allow adding — the pinboard
   // will be auto-created on first publish if none exists yet.
   const defaultBoardCoord = pinboards.length > 0 ? pinboards[0].coordinate : null;
-  const hasNostr = typeof window !== "undefined" && !!(window as any).nostr;
-  const canAdd = !!defaultBoardCoord || hasNostr;
+  const canAdd = !!defaultBoardCoord || !!user || hasExtension;
 
   return (
     <>
@@ -161,7 +172,7 @@ export default function EducationPage() {
             Education Resources
           </h1>
           <p className="text-lg text-gray-600 max-w-2xl mx-auto">
-            Curated collections of educational content, articles, links, and media about Bitcoin and sound money.
+            Curated collections of educational content, articles, links, and media about conservative values and civic engagement.
           </p>
         </div>
 
@@ -190,33 +201,51 @@ export default function EducationPage() {
         {/* Featured Resources View */}
         {view === "featured" && (
           <>
-            {loadingFeatured ? (
+            {/* Show action buttons and filter bar immediately */}
+            {(canAdd || featuredPins.length > 0) && (
+              <FilterBar
+                pins={activePins}
+                filter={displayFilter}
+                setFilter={setDisplayFilter}
+                sortBy={sortBy}
+                setSortBy={setSortBy}
+                onAddClick={() => setShowAddPin(true)}
+                canAdd={canAdd}
+              />
+            )}
+
+            {/* Loading state — only show spinner when no pins have arrived yet */}
+            {loadingFeatured && featuredPins.length === 0 && (
               <LoadingSpinner text="Loading featured resources..." />
-            ) : featuredPins.length === 0 && pinboards.length === 0 && !canAdd ? (
+            )}
+
+            {/* Empty state — only when loading is done and nothing arrived */}
+            {!loadingFeatured && featuredPins.length === 0 && pinboards.length === 0 && !canAdd && (
               <EmptyState />
-            ) : (
-              <>
-                <FilterBar
-                  pins={activePins}
-                  filter={displayFilter}
-                  setFilter={setDisplayFilter}
-                  sortBy={sortBy}
-                  setSortBy={setSortBy}
-                  onAddClick={() => setShowAddPin(true)}
-                  canAdd={canAdd}
-                />
-                {filteredPins.length === 0 ? (
-                  <div className="bg-gray-50 border border-gray-200 rounded-lg p-10 text-center">
-                    <p className="text-gray-600">No resources match this filter.</p>
-                  </div>
-                ) : (
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                    {filteredPins.map((pin) => (
-                      <PinCard key={pin.id} pin={pin} onDelete={() => handleDeletePin(pin)} onEdit={() => handleEditPin(pin)} />
-                    ))}
-                  </div>
-                )}
-              </>
+            )}
+
+            {/* No results for filter */}
+            {!loadingFeatured && featuredPins.length > 0 && filteredPins.length === 0 && (
+              <div className="bg-gray-50 border border-gray-200 rounded-lg p-10 text-center">
+                <p className="text-gray-600">No resources match this filter.</p>
+              </div>
+            )}
+
+            {/* Pin grid — render as pins arrive */}
+            {filteredPins.length > 0 && (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {filteredPins.map((pin) => (
+                  <PinCard key={pin.id} pin={pin} onDelete={() => handleDeletePin(pin)} onEdit={() => handleEditPin(pin)} />
+                ))}
+              </div>
+            )}
+
+            {/* Subtle loading indicator while still streaming more pins */}
+            {loadingFeatured && featuredPins.length > 0 && (
+              <div className="flex justify-center items-center py-4 gap-2 text-sm text-gray-400">
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-400" />
+                Loading more...
+              </div>
             )}
           </>
         )}
@@ -334,6 +363,8 @@ export default function EducationPage() {
             onDone={handlePinAdded}
             onCancel={() => { setShowAddPin(false); setEditPin(null); }}
             editPin={editPin}
+            pubkey={user?.pubkey}
+            signEvent={signEvent}
           />
         )}
       </div>
@@ -578,6 +609,10 @@ function PinCard({ pin, onDelete, onEdit }: { pin: Pin; onDelete: () => void; on
             ))}
           </div>
         )}
+
+        <div className="mt-2 pt-2 border-t border-gray-100 text-xs text-gray-400">
+          {new Date(pin.created_at * 1000).toLocaleDateString()}
+        </div>
       </div>
     </div>
   );
@@ -589,11 +624,15 @@ function AddPinModal({
   onDone,
   onCancel,
   editPin,
+  pubkey,
+  signEvent,
 }: {
   boardCoordinate: string;
   onDone: () => void;
   onCancel: () => void;
   editPin?: Pin | null;
+  pubkey?: string;
+  signEvent?: (event: { kind: number; content: string; tags: string[][]; created_at: number }) => Promise<Record<string, unknown>>;
 }) {
   const [title, setTitle] = useState(editPin?.title || "");
   const [url, setUrl] = useState(editPin?.externalRef || "");
@@ -631,13 +670,25 @@ function AddPinModal({
     setError("");
 
     try {
-      if (!window.nostr) {
-        setError("No Nostr extension found. Please install one to publish.");
+      if (!pubkey && !window.nostr) {
+        setError("You must be logged in to publish.");
         setPublishing(false);
         return;
       }
 
-      const pubkey = await window.nostr.getPublicKey();
+      // Helper to sign via either NostrContext or window.nostr extension
+      const doSign = async (evt: Record<string, unknown>) => {
+        if (signEvent && pubkey) {
+          return signEvent(evt as { kind: number; content: string; tags: string[][]; created_at: number });
+        }
+        if (window.nostr) {
+          const pk = await window.nostr.getPublicKey();
+          return window.nostr.signEvent({ ...evt, pubkey: pk });
+        }
+        throw new Error("No signing method available");
+      };
+
+      const resolvedPubkey = pubkey || (window.nostr ? await window.nostr.getPublicKey() : "");
 
       // Auto-create a pinboard if none exists yet ("auto" sentinel)
       let resolvedBoardCoord = boardCoordinate;
@@ -647,7 +698,7 @@ function AddPinModal({
           title: "Education",
           description: "Educational resources",
         });
-        const signedBoard = await window.nostr.signEvent({ ...unsignedBoard, pubkey });
+        const signedBoard = await doSign(unsignedBoard);
         const boardOk = await publishPinboard(signedBoard);
         if (!boardOk) {
           setError("Failed to create pinboard on relays.");
@@ -656,7 +707,7 @@ function AddPinModal({
         }
         // Construct the coordinate from the signed event
         const dTag = (signedBoard.tags as string[][]).find((t: string[]) => t[0] === "d")?.[1] || "education";
-        resolvedBoardCoord = `30067:${pubkey}:${dTag}`;
+        resolvedBoardCoord = `30067:${resolvedPubkey}:${dTag}`;
       }
 
       // Use detected content kind, but override displayType to match user's selection
@@ -681,7 +732,7 @@ function AddPinModal({
         dTag: isEditing ? (editPin?.rawEvent?.tags as string[][] | undefined)?.find((t) => t[0] === "d")?.[1] : undefined,
       });
 
-      const signedEvent = await window.nostr.signEvent({ ...unsignedEvent, pubkey });
+      const signedEvent = await doSign(unsignedEvent);
 
       const success = await publishPin(signedEvent);
       if (success) {
@@ -712,7 +763,7 @@ function AddPinModal({
               type="text"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              placeholder="e.g. The Bitcoin Standard"
+              placeholder="e.g. How a Bill Becomes a Law"
               className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"
             />
           </div>
@@ -793,7 +844,7 @@ function AddPinModal({
               type="text"
               value={tags}
               onChange={(e) => setTags(e.target.value)}
-              placeholder="bitcoin, economics, education"
+              placeholder="education, civics, conservative"
               className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"
             />
           </div>
@@ -836,7 +887,7 @@ function LoadingSpinner({ text }: { text: string }) {
 function EmptyState() {
   return (
     <div className="bg-gray-50 border border-gray-200 rounded-lg p-12 text-center">
-      <span className="text-6xl block mb-4">{"{}"}</span>
+      <span className="text-6xl block mb-4">📌</span>
       <h3 className="text-xl font-bold text-gray-800 mb-2">No Pinboards Yet</h3>
       <p className="text-gray-600">Pinboards are curated collections of educational content. Check back soon for new resources!</p>
     </div>

--- a/src/utils/committeeEvents.ts
+++ b/src/utils/committeeEvents.ts
@@ -1,0 +1,429 @@
+import { pool } from "@/lib/nostr";
+import { nostrRelays, WHITELISTED_PUBKEYS } from "@/config";
+import { buildDeleteEvent, publishDelete } from "@/utils/pinboardEvents";
+import { logger } from "@/utils/logger";
+
+// --- Interfaces ---
+
+export interface Committee {
+  id: string;
+  pubkey: string;
+  dTag: string;
+  title: string;
+  description: string;
+  image?: string;
+  meetingSchedule?: string;
+  openings: number;
+  tags: string[];
+  coordinate: string;
+  created_at: number;
+  rawEvent?: Record<string, unknown>;
+}
+
+export interface CommitteeMember {
+  id: string;
+  pubkey: string;
+  committeeCoordinate: string;
+  dTag: string;
+  role: string;
+  name: string;
+  email?: string;
+  phone?: string;
+  nostrPubkey?: string;
+  created_at: number;
+  rawEvent?: Record<string, unknown>;
+}
+
+export interface CommitteeOpening {
+  id: string;
+  pubkey: string;
+  committeeCoordinate: string;
+  dTag: string;
+  title: string;
+  description?: string;
+  created_at: number;
+  rawEvent?: Record<string, unknown>;
+}
+
+// --- Build functions ---
+
+export function buildCommitteeEvent(opts: {
+  dTag: string;
+  title: string;
+  description?: string;
+  image?: string;
+  meetingSchedule?: string;
+  openings?: number;
+  topicTags?: string[];
+}): Record<string, unknown> {
+  const tags: string[][] = [["d", opts.dTag]];
+  if (opts.title) tags.push(["title", opts.title]);
+  if (opts.description) tags.push(["description", opts.description]);
+  if (opts.image) tags.push(["image", opts.image]);
+  if (opts.meetingSchedule) tags.push(["meetingSchedule", opts.meetingSchedule]);
+  if (opts.openings !== undefined) tags.push(["openings", String(opts.openings)]);
+  if (opts.topicTags) {
+    for (const t of opts.topicTags) tags.push(["t", t]);
+  }
+  return {
+    kind: 30068,
+    content: opts.description || "",
+    tags,
+    created_at: Math.floor(Date.now() / 1000),
+  };
+}
+
+export function buildCommitteeMemberEvent(opts: {
+  committeeCoordinate: string;
+  dTag: string;
+  role: string;
+  name: string;
+  email?: string;
+  phone?: string;
+  nostrPubkey?: string;
+}): Record<string, unknown> {
+  const tags: string[][] = [
+    ["a", opts.committeeCoordinate],
+    ["d", opts.dTag],
+    ["role", opts.role],
+    ["name", opts.name],
+  ];
+  if (opts.email) tags.push(["email", opts.email]);
+  if (opts.phone) tags.push(["phone", opts.phone]);
+  if (opts.nostrPubkey) tags.push(["p", opts.nostrPubkey]);
+  return {
+    kind: 39068,
+    content: "",
+    tags,
+    created_at: Math.floor(Date.now() / 1000),
+  };
+}
+
+export function buildCommitteeOpeningEvent(opts: {
+  committeeCoordinate: string;
+  dTag: string;
+  title: string;
+  description?: string;
+}): Record<string, unknown> {
+  const tags: string[][] = [
+    ["a", opts.committeeCoordinate],
+    ["d", opts.dTag],
+    ["title", opts.title],
+  ];
+  if (opts.description) tags.push(["description", opts.description]);
+  return {
+    kind: 39069,
+    content: opts.description || "",
+    tags,
+    created_at: Math.floor(Date.now() / 1000),
+  };
+}
+
+// --- Publish functions ---
+
+export async function publishCommittee(signedEvent: Record<string, unknown>): Promise<boolean> {
+  try {
+    const responses = await pool.publish(nostrRelays, signedEvent as any);
+    return responses.some((r) => r.ok);
+  } catch {
+    return false;
+  }
+}
+
+export async function publishCommitteeMember(signedEvent: Record<string, unknown>): Promise<boolean> {
+  try {
+    const responses = await pool.publish(nostrRelays, signedEvent as any);
+    return responses.some((r) => r.ok);
+  } catch {
+    return false;
+  }
+}
+
+export async function publishCommitteeOpening(signedEvent: Record<string, unknown>): Promise<boolean> {
+  try {
+    const responses = await pool.publish(nostrRelays, signedEvent as any);
+    return responses.some((r) => r.ok);
+  } catch {
+    return false;
+  }
+}
+
+// Re-export delete helpers from pinboardEvents for convenience
+export { buildDeleteEvent, publishDelete };
+
+// --- Whitelist helper ---
+
+// Resolve the author list at query time so test-injected pubkeys
+// (window.__TEST_WHITELIST) are included alongside the config pubkeys.
+function getAuthorPubkeys(): string[] {
+  const base = WHITELISTED_PUBKEYS;
+  if (typeof window !== "undefined" && (window as any).__TEST_WHITELIST) {
+    const extra = (window as any).__TEST_WHITELIST as string[];
+    const merged = new Set([...base, ...extra]);
+    return Array.from(merged);
+  }
+  return base;
+}
+
+// --- Fetch functions ---
+
+// Deduplicate parameterized replaceable events by coordinate (keep latest)
+function deduplicateByCoordinate(events: any[], kind: number): any[] {
+  const map = new Map<string, any>();
+  for (const event of events) {
+    const dTag = event.tags?.find((t: string[]) => t[0] === "d")?.[1] || "";
+    const coord = `${kind}:${event.pubkey}:${dTag}`;
+    const existing = map.get(coord);
+    if (!existing || event.created_at > existing.created_at) {
+      map.set(coord, event);
+    }
+  }
+  return Array.from(map.values());
+}
+
+export async function fetchCommittees(): Promise<Committee[]> {
+  const relays = nostrRelays;
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => resolve([]), 15000);
+    const rawEvents: any[] = [];
+
+    const authors = getAuthorPubkeys();
+    pool.request(relays, {
+      kinds: [30068],
+      authors,
+      limit: 100,
+    }).subscribe({
+      next: (event) => rawEvents.push(event),
+      error: () => { clearTimeout(timeout); resolve([]); },
+      complete: () => {
+        clearTimeout(timeout);
+        const authorSet = new Set(authors);
+        const filtered = rawEvents.filter((e: any) => authorSet.has(e.pubkey));
+        const deduped = deduplicateByCoordinate(filtered, 30068);
+        const committees: Committee[] = deduped.map(parseCommitteeEvent).filter(Boolean) as Committee[];
+        resolve(committees.sort((a, b) => a.title.localeCompare(b.title)));
+      },
+    });
+  });
+}
+
+export async function fetchMembersForAllCommittees(
+  committees: Committee[],
+): Promise<Map<string, CommitteeMember[]>> {
+  const relays = nostrRelays;
+  const result = new Map<string, CommitteeMember[]>();
+
+  if (committees.length === 0) return result;
+
+  const coordinates = committees.map((c) => c.coordinate);
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => resolve(result), 15000);
+    const rawEvents: any[] = [];
+
+    pool.request(relays, {
+      kinds: [39068],
+      "#a": coordinates,
+      limit: 500,
+    }).subscribe({
+      next: (event) => rawEvents.push(event),
+      error: () => { clearTimeout(timeout); resolve(result); },
+      complete: () => {
+        clearTimeout(timeout);
+        for (const event of rawEvents) {
+          const member = parseCommitteeMemberEvent(event);
+          if (member) {
+            const existing = result.get(member.committeeCoordinate) || [];
+            existing.push(member);
+            result.set(member.committeeCoordinate, existing);
+          }
+        }
+        // Sort each committee's members: chair first, then vice-chair, then members, then by name
+        for (const [coord, members] of result.entries()) {
+          result.set(coord, members.sort((a, b) => {
+            const roleOrder: Record<string, number> = { chair: 0, "vice-chair": 1, member: 2 };
+            const diff = (roleOrder[a.role] ?? 2) - (roleOrder[b.role] ?? 2);
+            if (diff !== 0) return diff;
+            return a.name.localeCompare(b.name);
+          }));
+        }
+        resolve(result);
+      },
+    });
+  });
+}
+
+export async function fetchMembersForCommittee(
+  committee: Committee,
+): Promise<CommitteeMember[]> {
+  const relays = nostrRelays;
+  const coordinate = committee.coordinate;
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => resolve([]), 15000);
+    const rawEvents: any[] = [];
+
+    pool.request(relays, {
+      kinds: [39068],
+      "#a": [coordinate],
+      limit: 200,
+    }).subscribe({
+      next: (event) => rawEvents.push(event),
+      error: () => { clearTimeout(timeout); resolve([]); },
+      complete: () => {
+        clearTimeout(timeout);
+        const members: CommitteeMember[] = rawEvents
+          .map(parseCommitteeMemberEvent)
+          .filter((m): m is CommitteeMember => {
+            if (!m) return false;
+            // Deduplicate by dTag (keep latest)
+            return true;
+          });
+
+        // Deduplicate by dTag
+        const byDTag = new Map<string, CommitteeMember>();
+        for (const m of members) {
+          const existing = byDTag.get(m.dTag);
+          if (!existing || m.created_at > existing.created_at) {
+            byDTag.set(m.dTag, m);
+          }
+        }
+
+        const deduped = Array.from(byDTag.values());
+        deduped.sort((a, b) => {
+          const roleOrder: Record<string, number> = { chair: 0, "vice-chair": 1, member: 2 };
+          const diff = (roleOrder[a.role] ?? 2) - (roleOrder[b.role] ?? 2);
+          if (diff !== 0) return diff;
+          return a.name.localeCompare(b.name);
+        });
+
+        resolve(deduped);
+      },
+    });
+  });
+}
+
+export async function fetchOpeningsForAllCommittees(
+  committees: Committee[],
+): Promise<Map<string, CommitteeOpening[]>> {
+  const relays = nostrRelays;
+  const result = new Map<string, CommitteeOpening[]>();
+
+  if (committees.length === 0) return result;
+
+  const coordinates = committees.map((c) => c.coordinate);
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => resolve(result), 15000);
+    const rawEvents: any[] = [];
+
+    pool.request(relays, {
+      kinds: [39069],
+      "#a": coordinates,
+      limit: 500,
+    }).subscribe({
+      next: (event) => rawEvents.push(event),
+      error: () => { clearTimeout(timeout); resolve(result); },
+      complete: () => {
+        clearTimeout(timeout);
+        const byDTag = new Map<string, CommitteeOpening>();
+        for (const event of rawEvents) {
+          const opening = parseCommitteeOpeningEvent(event);
+          if (opening) {
+            const key = `${opening.committeeCoordinate}:${opening.dTag}`;
+            const existing = byDTag.get(key);
+            if (!existing || opening.created_at > existing.created_at) {
+              byDTag.set(key, opening);
+            }
+          }
+        }
+        for (const opening of byDTag.values()) {
+          const existing = result.get(opening.committeeCoordinate) || [];
+          existing.push(opening);
+          result.set(opening.committeeCoordinate, existing);
+        }
+        resolve(result);
+      },
+    });
+  });
+}
+
+// --- Parse helpers ---
+
+function parseCommitteeEvent(event: any): Committee | null {
+  const dTag = event.tags?.find((t: string[]) => t[0] === "d")?.[1];
+  if (!dTag) return null;
+
+  const title = event.tags?.find((t: string[]) => t[0] === "title")?.[1] || dTag;
+  const description = event.tags?.find((t: string[]) => t[0] === "description")?.[1] || event.content || "";
+  const image = event.tags?.find((t: string[]) => t[0] === "image")?.[1];
+  const meetingSchedule = event.tags?.find((t: string[]) => t[0] === "meetingSchedule")?.[1];
+  const openingsStr = event.tags?.find((t: string[]) => t[0] === "openings")?.[1];
+  const openings = openingsStr ? parseInt(openingsStr, 10) : 0;
+  const tags = event.tags?.filter((t: string[]) => t[0] === "t").map((t: string[]) => t[1]) || [];
+
+  return {
+    id: event.id,
+    pubkey: event.pubkey,
+    dTag,
+    title,
+    description,
+    image,
+    meetingSchedule,
+    openings: isNaN(openings) ? 0 : openings,
+    tags,
+    coordinate: `30068:${event.pubkey}:${dTag}`,
+    created_at: event.created_at,
+    rawEvent: event,
+  };
+}
+
+function parseCommitteeMemberEvent(event: any): CommitteeMember | null {
+  const aTag = event.tags?.find((t: string[]) => t[0] === "a" || t[0] === "A")?.[1];
+  const dTag = event.tags?.find((t: string[]) => t[0] === "d")?.[1];
+  const name = event.tags?.find((t: string[]) => t[0] === "name")?.[1];
+
+  if (!aTag || !dTag || !name) return null;
+
+  const roleRaw = event.tags?.find((t: string[]) => t[0] === "role")?.[1] || "member";
+  const role = roleRaw;
+  const email = event.tags?.find((t: string[]) => t[0] === "email")?.[1];
+  const phone = event.tags?.find((t: string[]) => t[0] === "phone")?.[1];
+  const nostrPubkey = event.tags?.find((t: string[]) => t[0] === "p")?.[1];
+
+  return {
+    id: event.id,
+    pubkey: event.pubkey,
+    committeeCoordinate: aTag,
+    dTag,
+    role,
+    name,
+    email,
+    phone,
+    nostrPubkey,
+    created_at: event.created_at,
+    rawEvent: event,
+  };
+}
+
+function parseCommitteeOpeningEvent(event: any): CommitteeOpening | null {
+  const aTag = event.tags?.find((t: string[]) => t[0] === "a" || t[0] === "A")?.[1];
+  const dTag = event.tags?.find((t: string[]) => t[0] === "d")?.[1];
+  const title = event.tags?.find((t: string[]) => t[0] === "title")?.[1];
+
+  if (!aTag || !dTag || !title) return null;
+
+  const description = event.tags?.find((t: string[]) => t[0] === "description")?.[1] || event.content || "";
+
+  return {
+    id: event.id,
+    pubkey: event.pubkey,
+    committeeCoordinate: aTag,
+    dTag,
+    title,
+    description: description || undefined,
+    created_at: event.created_at,
+    rawEvent: event,
+  };
+}


### PR DESCRIPTION
## Summary
Ports recent changes from the ray_repub repo, adapted for KC Bitcoiners:
- Committee openings system (kind 39069 events) with CRUD modals
- Flexible committee roles (free-form text instead of hardcoded dropdown)
- EventActions dropdown positioning fix (fixed positioning to prevent clipping)
- Education page: `hasExtension` check for admin controls, `window.nostr` signing fallback
- Committee member/contact expandable details with markdown descriptions
- `react-markdown` dependency added

Theme-specific references (republican-red) converted to bitcoin-orange. Org-specific text updated.

## Test plan
- [ ] Verify committees page loads and displays openings
- [ ] Verify EventActions dropdown no longer clips in modals
- [ ] Verify education page admin controls appear with extension present
- [ ] Verify committee member roles are free-form text

🤖 Generated with [Claude Code](https://claude.com/claude-code)