### PR TITLE
Exclude playwright/test files from TypeScript build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "playwright.config.ts", "tests"]
 }


### PR DESCRIPTION
## Summary
- Exclude `playwright.config.ts` and `tests/` from `tsconfig.json` include scope
- Fixes CI build failure: `Cannot find module '@playwright/test'` — it's a devDependency not installed in the production build environment

## Test plan
- [x] `next build` passes locally
- [ ] CI build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)