### PR TITLE
Add all pages to post-build clean URL generation

### DIFF
--- a/scripts/post-build.js
+++ b/scripts/post-build.js
@@ -11,6 +11,11 @@ const outDir = path.join(__dirname, '../out');
 // Pages that need clean URLs
 const pages = [
   'calendar',
+  'committees',
+  'donate',
+  'education',
+  'events',
+  'gallery',
   'shop',
 ];
 

--- a/scripts/post-build.js
+++ b/scripts/post-build.js
@@ -8,20 +8,14 @@ const path = require('path');
 
 const outDir = path.join(__dirname, '../out');
 
-// Pages that need clean URLs
-const pages = [
-  'calendar',
-  'committees',
-  'donate',
-  'education',
-  'events',
-  'gallery',
-  'shop',
-];
+// Automatically detect all page HTML files (skip index.html and 404.html)
+const pages = fs.readdirSync(outDir)
+  .filter(f => f.endsWith('.html') && f !== 'index.html' && f !== '404.html')
+  .map(f => f.replace('.html', ''));
 
 function createCleanUrls() {
   console.log('Creating clean URL structure...');
-  
+
   pages.forEach(page => {
     const sourceFile = path.join(outDir, `${page}.html`);
     const targetDir = path.join(outDir, page);


### PR DESCRIPTION
## Summary
- Add committees, donate, education, events, and gallery to `post-build.js` clean URL list
- Only calendar and shop had `page/index.html` structure, all others 404'd on direct access

## Test plan
- [x] `npm run build && node scripts/post-build.js` creates `page/index.html` for all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)