### PR TITLE
refactor: remove hard-coded community values, use config (issue #28)

### DIFF
--- a/src/components/NewsletterForm.tsx
+++ b/src/components/NewsletterForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { siteConfig } from "@/config";
 
 interface NewsletterFormData {
   name: string;
@@ -97,7 +98,7 @@ export default function NewsletterForm() {
         {isSubmitting ? "Subscribing..." : "Subscribe"}
       </button>
       <p className="text-xs text-gray-500 text-center">
-        By subscribing, you agree to receive email updates from KC Bitcoiners.
+        By subscribing, you agree to receive email updates from {siteConfig.organization.name}.
       </p>
     </form>
   );

--- a/src/components/VendorForm.tsx
+++ b/src/components/VendorForm.tsx
@@ -2,8 +2,11 @@ import { useNostr } from "@/contexts/NostrContext";
 import { naddrEncode } from "applesauce-core/helpers";
 import { useEffect, useState } from "react";
 import { XIcon } from "./Icons";
-import { nostrRelays } from "@/config";
+import { nostrRelays, siteConfig } from "@/config";
 import { logger } from "@/utils/logger";
+
+// Default coordinates from config
+const { lat: DEFAULT_LAT, lon: DEFAULT_LON } = siteConfig.organization.coordinates;
 
 // RochesterKC business data
 const ROCHESTERKC_DATA = {
@@ -14,18 +17,18 @@ const ROCHESTERKC_DATA = {
   lightningAddress: "rochesterkc@getalby.com",
   onchainAddress:
     "bc1qxfzq9yp7s4xqfz8xq7hj0xvq7xq5xq3xq7hj0xvq7xq5xq3xq7hj0xvq7",
-  notes: "Coworking space and Bitcoin community hub in Kansas City",
+  notes: `Coworking space and Bitcoin community hub in ${siteConfig.organization.location}`,
   contact: "913-491-2969",
-  address: "1520 Holmes St, Kansas City, MO 64102",
+  address: `1520 Holmes St, ${siteConfig.organization.location}, MO 64102`,
   website: "https://rochesterkc.com",
   phone: "913-491-2969",
-  lat: 39.0943,
-  lon: -94.5829,
+  lat: DEFAULT_LAT,
+  lon: DEFAULT_LON,
   email: "info@rochesterkc.com",
   twitter: "@RochesterKC",
   mastodon: "@rochesterkc@mastodon.social",
   description:
-    "RochesterKC is a vibrant coworking space and Bitcoin community hub located in the Crossroads Arts District of Kansas City. We provide a collaborative environment for entrepreneurs, developers, and Bitcoin enthusiasts to work, network, and learn together.",
+    `RochesterKC is a vibrant coworking space and Bitcoin community hub located in the Crossroads Arts District of ${siteConfig.organization.location}. We provide a collaborative environment for entrepreneurs, developers, and Bitcoin enthusiasts to work, network, and learn together.`,
   opening_hours: "Mon-Fri 9am-6pm, Sat 10am-4pm, Closed Sunday",
 };
 
@@ -757,7 +760,7 @@ export default function VendorForm({
                     )
                   }
                   className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"
-                  placeholder="39.0997"
+                  placeholder={String(DEFAULT_LAT)}
                 />
               </div>
 
@@ -776,7 +779,7 @@ export default function VendorForm({
                     )
                   }
                   className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"
-                  placeholder="-94.5786"
+                  placeholder={String(DEFAULT_LON)}
                 />
               </div>
             </div>

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -108,8 +108,8 @@ export const getExternalLink = (name: string) => externalLinks[name];
 export const getMeetupUrl = () => externalLinks.meetup?.url;
 export const getGithubUrl = () => externalLinks.GitHub?.url;
 
-// Constants for backward compatibility
-export const KC_BITCOINERS_RELAY = "wss://kcbtc.hzrd149.com/";
+// Community relay -- first relay from config is the community relay
+export const KC_BITCOINERS_RELAY = nostrRelays[0] || "wss://kcbtc.hzrd149.com/";
 
 // Social links interface and data (moved from socialLinks.ts)
 export interface SocialLink {

--- a/src/pages/education.tsx
+++ b/src/pages/education.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
 import Head from "next/head";
-import { config } from "@/config";
+import { config, siteConfig } from "@/config";
 import {
   fetchPinboards,
   fetchFeaturedPins,
@@ -905,7 +905,7 @@ function AddPinModal({
                 {selectedType === "book" && "Enter an ISBN like isbn:978... or a bare ISBN number"}
                 {selectedType === "movie" && "Enter an ISAN like isan:XXXX-XXXX-XXXX"}
                 {selectedType === "paper" && "Enter a DOI like doi:10.xxx or 10.xxx/yyy"}
-                {selectedType === "location" && "Enter coordinates like geo:39.23,-94.03 or lat,lon"}
+                {selectedType === "location" && `Enter coordinates like geo:${siteConfig.organization.coordinates.lat},${siteConfig.organization.coordinates.lon} or lat,lon`}
               </p>
             )}
           </div>
@@ -924,7 +924,7 @@ function AddPinModal({
                 : selectedType === "book" ? "isbn:9780743273565 or bare ISBN"
                 : selectedType === "movie" ? "isan:XXXX-XXXX-XXXX-XXXX"
                 : selectedType === "paper" ? "doi:10.1000/xyz123 or 10.xxxx/yyyy"
-                : selectedType === "location" ? "geo:39.23,-94.03 or 39.23,-94.03"
+                : selectedType === "location" ? `geo:${siteConfig.organization.coordinates.lat},${siteConfig.organization.coordinates.lon} or ${siteConfig.organization.coordinates.lat},${siteConfig.organization.coordinates.lon}`
                 : "Select a content type first"
               }
               className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-bitcoin-orange focus:border-transparent"

--- a/src/pages/gallery.tsx
+++ b/src/pages/gallery.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import Head from "next/head";
-import { config } from "@/config";
+import { config, siteConfig } from "@/config";
 import { streamGalleryImages, GalleryImage, publishGalleryImage, uploadToBlossom } from "@/utils/galleryEvents";
 import { buildDeleteEvent, publishDelete } from "@/utils/pinboardEvents";
 import { useNostr } from "@/contexts/NostrContext";
@@ -50,7 +50,7 @@ export default function GalleryPage() {
             Gallery
           </h1>
           <p className="text-lg text-gray-600 max-w-2xl mx-auto">
-            Photos from KC Bitcoiners events, meetups, and community activities.
+            Photos from {siteConfig.organization.name} events, meetups, and community activities.
           </p>
         </div>
 

--- a/src/pages/shop.tsx
+++ b/src/pages/shop.tsx
@@ -5,7 +5,7 @@ import EventActions from "@/components/EventActions";
 import { useNostr } from "@/contexts/NostrContext";
 import { fetchBTCMapVendors, BTCMapVendor } from "@/utils/btcmap";
 import { pool } from "@/lib/nostr";
-import { config, nostrRelays, getWhitelistFilter } from "@/config";
+import { config, nostrRelays, getWhitelistFilter, siteConfig } from "@/config";
 import type { Icon, LatLngBounds, DivIcon } from "leaflet";
 import { getEventHash, type NostrEvent } from "applesauce-core/helpers/event";
 
@@ -1154,7 +1154,7 @@ export default function ShopPage() {
                 🚀 Add Your First Vendor
               </h3>
               <p className="text-gray-600 mb-4">
-                Help grow the Bitcoin ecosystem in Kansas City by submitting local businesses that accept Bitcoin payments.
+                Help grow the Bitcoin ecosystem in {siteConfig.organization.location} by submitting local businesses that accept Bitcoin payments.
               </p>
               <button
                 onClick={() => setShowVendorForm(true)}


### PR DESCRIPTION
- Replace hard-coded KC_BITCOINERS_RELAY with first relay from config
- Replace hard-coded coordinates in VendorForm with config values
- Replace hard-coded location names in education placeholders
- Replace 'Kansas City' in shop.tsx with config.organization.location
- Replace 'KC Bitcoiners' in gallery.tsx with config.organization.name
- Replace 'KC Bitcoiners' in NewsletterForm with config.organization.name
- Remaining: icalendar.ts fallbacks (already read from config), placeholder address in VendorForm (generic example)