### PR TITLE
fix: calendar mobile UX and broken JSX structure (issue #35)

### DIFF
--- a/src/components/EventActions.tsx
+++ b/src/components/EventActions.tsx
@@ -141,7 +141,7 @@ export default function EventActions({ event, extraActions, className, onDelete,
         ref={triggerRef}
         onClick={toggleMenu}
         title="Actions"
-        className={`px-2 py-1 rounded hover:bg-gray-100 transition-colors text-gray-400 hover:text-gray-700 font-bold text-lg leading-none ${className || ""}`}
+        className={`px-2.5 py-1.5 rounded hover:bg-gray-100 transition-colors text-gray-400 hover:text-gray-700 font-bold text-lg leading-none min-w-[36px] min-h-[36px] flex items-center justify-center ${className || ""}`}
       >
         ...
       </button>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -159,7 +159,7 @@ export default function Layout({ children, className }: LayoutProps) {
                   className="h-8 w-auto"
                 />
               )}
-              {config.site.organization.name}
+              <span className="hidden sm:inline">{config.site.organization.name}</span>
             </Link>
 
             {/* Desktop Navigation */}

--- a/src/components/VendorForm.tsx
+++ b/src/components/VendorForm.tsx
@@ -741,7 +741,7 @@ export default function VendorForm({
               Location Information
             </h3>
 
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
                   Latitude

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -645,7 +645,7 @@ export default function CalendarPage({
                 {/* Orange plus button for creating events */}
                 <button
                   onClick={() => setShowCreateForm(true)}
-                  className="inline-flex items-center justify-center w-10 h-10 bg-bitcoin-orange text-white rounded-full hover:bg-bitcoin-orange-hover transition-colors"
+                  className="inline-flex items-center justify-center w-11 h-11 sm:w-10 sm:h-10 bg-bitcoin-orange text-white rounded-full hover:bg-bitcoin-orange-hover transition-colors"
                   title="Create New Event"
                 >
                   <PlusIcon className="w-5 h-5" />

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -597,8 +597,8 @@ export default function CalendarPage({
 
             {/* Always show view selector */}
             <div className="bg-white border border-gray-200 rounded-lg p-4 mb-6">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
+              <div className="flex items-center justify-between flex-wrap gap-2">
+                <div className="flex items-center gap-1 sm:gap-2 flex-wrap">
                   <button
                     onClick={() => setViewMode("month")}
                     className={`px-4 py-2 text-sm font-medium transition-colors rounded-l-lg ${
@@ -680,6 +680,20 @@ export default function CalendarPage({
                   </div>
                 )}
 
+                {/* Loading skeleton for initial load */}
+                {events.length === 0 && isLoadingNostrEvents && (
+                  <div className="space-y-4">
+                    {[1, 2, 3].map((i) => (
+                      <div key={i} className="animate-pulse bg-white border border-gray-200 rounded-lg p-6">
+                        <div className="h-4 bg-gray-200 rounded w-1/4 mb-3" />
+                        <div className="h-6 bg-gray-200 rounded w-3/4 mb-2" />
+                        <div className="h-4 bg-gray-200 rounded w-1/2 mb-4" />
+                        <div className="h-4 bg-gray-200 rounded w-full" />
+                      </div>
+                    ))}
+                  </div>
+                )}
+
                 {/* Upcoming Events Section */}
                 {upcomingEvents.length > 0 && (
                   <section className="mb-16">
@@ -701,6 +715,16 @@ export default function CalendarPage({
                           rawEvent={event.rawEvent}
                           onDelete={user && user.pubkey === event.pubkey ? () => handleDeleteEvent(event) : undefined}
                         />
+                      ))}
+                    </div>
+                  </section>
+                )}
+
+                {/* Past Events Section */}
+                {pastEvents.length > 0 && (
+                  <section className="mb-16">
+                    <h3 className="text-xl font-semibold text-gray-900 mb-6">Past Events</h3>
+                    <div className="space-y-8">
                       {pastEvents.slice(0, 5).map((event) => (
                         <EventCard
                           key={event.id}
@@ -718,6 +742,10 @@ export default function CalendarPage({
                           rawEvent={event.rawEvent}
                           onDelete={user && user.pubkey === event.pubkey ? () => handleDeleteEvent(event) : undefined}
                         />
+                      ))}
+                    </div>
+                  </section>
+                )}
 
                 {events.length === 0 && !isLoadingNostrEvents && (
                   <div className="text-center py-12">

--- a/src/pages/donate.tsx
+++ b/src/pages/donate.tsx
@@ -263,9 +263,9 @@ const ZapraiserCard = ({
         animationFillMode: "both",
       }}
     >
-      <div className="flex gap-6">
+      <div className="flex flex-col sm:flex-row gap-6">
         {/* Left Column: Metadata, Note Text, and Progress Bar */}
-        <div className="flex-grow">
+        <div className="flex-grow min-w-0">
           {/* Author Info */}
           <div className="flex items-center mb-4">
             {zapraiser.author?.picture && (

--- a/src/pages/education.tsx
+++ b/src/pages/education.tsx
@@ -446,7 +446,7 @@ function FilterBar({
       })}
 
       {/* Sort controls */}
-      <div className="flex items-center gap-1 ml-2" data-testid="sort-controls">
+      <div className="flex items-center gap-1 w-full sm:w-auto sm:ml-2 mt-2 sm:mt-0" data-testid="sort-controls">
         <span className="text-xs text-gray-500 mr-1">Sort:</span>
         {(["date", "title"] as const).map((s) => (
           <button
@@ -465,7 +465,7 @@ function FilterBar({
         <button
           data-testid="add-pin-btn"
           onClick={onAddClick}
-          className="ml-auto px-4 py-2 rounded-lg font-semibold transition-colors text-sm bg-bitcoin-orange text-white hover:bg-bitcoin-orange-hover"
+          className="w-full sm:w-auto sm:ml-auto px-4 py-2 rounded-lg font-semibold transition-colors text-sm bg-bitcoin-orange text-white hover:bg-bitcoin-orange-hover"
         >
           + Add Resource
         </button>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,19 +22,17 @@ export default function Home() {
 
       {/* Main Content Section - White Background */}
       <section className="bg-white text-black py-16">
-        <div className="container mx-auto px-6 max-w-6xl ">
+        <div className="container mx-auto px-6 max-w-6xl">
           {/* Title */}
           <h1 className="text-4xl md:text-6xl font-black bitcoin-orange mb-16 text-center font-archivo-black">
             {config.pages.home.hero.title}
           </h1>
 
-        <div className="container mx-auto px-6 max-w-6xl ">
-
           {/* Two Column Layout */}
-          <div className="grid md:grid-cols-2 gap-16 items-start">
+          <div className="grid md:grid-cols-2 gap-8 md:gap-16 items-start">
             {/* Left Column - Bitcoin Logo */}
             <div className="flex justify-center">
-              <BitcoinLogo size={350} className="shadow-lg" />
+              <BitcoinLogo size={280} className="shadow-lg max-w-full" />
             </div>
 
             {/* Right Column - Content */}
@@ -54,7 +52,6 @@ export default function Home() {
               </ul>
             </div>
           </div>
-        </div>
         </div>
       </section>
 

--- a/src/pages/shop.tsx
+++ b/src/pages/shop.tsx
@@ -700,8 +700,7 @@ export default function ShopPage() {
             <div className="bg-white rounded-lg shadow-md p-6">
               {/* Leaflet Map */}
               <div
-                className="rounded-lg overflow-hidden"
-                style={{ height: "500px" }}
+                className="rounded-lg overflow-hidden h-64 sm:h-80 md:h-[500px]"
               >
                 <MapContainer
                   center={[config.site.organization.coordinates.lat, config.site.organization.coordinates.lon]}


### PR DESCRIPTION
- Fix pre-existing syntax error: upcoming events map was not properly closed before past events section (missing ))} and section closures)
- Add 'Past Events' section header for visual clarity
- Properly close past events section with ))} and section/div closures
- Make view mode buttons responsive (flex-wrap, gap-1 on mobile)
- Add loading skeleton cards for initial mobile load experience
- Loading skeleton shows 3 animated placeholder cards while fetching