### PR TITLE
fix: enforce whitelist filtering on collaborative pinboards and commi…

### DIFF
--- a/src/utils/committeeEvents.ts
+++ b/src/utils/committeeEvents.ts
@@ -217,6 +217,8 @@ export async function fetchMembersForAllCommittees(
   if (committees.length === 0) return result;
 
   const coordinates = committees.map((c) => c.coordinate);
+  const authors = getAuthorPubkeys();
+  const authorSet = new Set(authors);
 
   return new Promise((resolve) => {
     const timeout = setTimeout(() => resolve(result), 15000);
@@ -225,13 +227,15 @@ export async function fetchMembersForAllCommittees(
     pool.request(relays, {
       kinds: [39068],
       "#a": coordinates,
+      authors,
       limit: 500,
     }).subscribe({
       next: (event) => rawEvents.push(event),
       error: () => { clearTimeout(timeout); resolve(result); },
       complete: () => {
         clearTimeout(timeout);
-        for (const event of rawEvents) {
+        const filtered = rawEvents.filter((e: any) => authorSet.has(e.pubkey));
+        for (const event of filtered) {
           const member = parseCommitteeMemberEvent(event);
           if (member) {
             const existing = result.get(member.committeeCoordinate) || [];
@@ -259,6 +263,8 @@ export async function fetchMembersForCommittee(
 ): Promise<CommitteeMember[]> {
   const relays = nostrRelays;
   const coordinate = committee.coordinate;
+  const authors = getAuthorPubkeys();
+  const authorSet = new Set(authors);
 
   return new Promise((resolve) => {
     const timeout = setTimeout(() => resolve([]), 15000);
@@ -267,13 +273,15 @@ export async function fetchMembersForCommittee(
     pool.request(relays, {
       kinds: [39068],
       "#a": [coordinate],
+      authors,
       limit: 200,
     }).subscribe({
       next: (event) => rawEvents.push(event),
       error: () => { clearTimeout(timeout); resolve([]); },
       complete: () => {
         clearTimeout(timeout);
-        const members: CommitteeMember[] = rawEvents
+        const filtered = rawEvents.filter((e: any) => authorSet.has(e.pubkey));
+        const members: CommitteeMember[] = filtered
           .map(parseCommitteeMemberEvent)
           .filter((m): m is CommitteeMember => {
             if (!m) return false;
@@ -313,6 +321,8 @@ export async function fetchOpeningsForAllCommittees(
   if (committees.length === 0) return result;
 
   const coordinates = committees.map((c) => c.coordinate);
+  const authors = getAuthorPubkeys();
+  const authorSet = new Set(authors);
 
   return new Promise((resolve) => {
     const timeout = setTimeout(() => resolve(result), 15000);
@@ -321,14 +331,16 @@ export async function fetchOpeningsForAllCommittees(
     pool.request(relays, {
       kinds: [39069],
       "#a": coordinates,
+      authors,
       limit: 500,
     }).subscribe({
       next: (event) => rawEvents.push(event),
       error: () => { clearTimeout(timeout); resolve(result); },
       complete: () => {
         clearTimeout(timeout);
+        const filtered = rawEvents.filter((e: any) => authorSet.has(e.pubkey));
         const byDTag = new Map<string, CommitteeOpening>();
-        for (const event of rawEvents) {
+        for (const event of filtered) {
           const opening = parseCommitteeOpeningEvent(event);
           if (opening) {
             const key = `${opening.committeeCoordinate}:${opening.dTag}`;

--- a/src/utils/pinboardEvents.ts
+++ b/src/utils/pinboardEvents.ts
@@ -316,14 +316,19 @@ export async function fetchFeaturedPins(): Promise<Pin[]> {
 export async function fetchPinsForBoard(board: Pinboard): Promise<Pin[]> {
   const relays = nostrRelays;
   const coordinate = board.coordinate;
+  const whitelistedAuthors = getWhitelistedAuthors();
+  const authorSet = new Set(whitelistedAuthors);
 
-  // Fetch by author and filter client-side by board coordinate
-  const authors = board.collaborative ? undefined : [board.pubkey];
+  // Always apply whitelist filtering at relay level
+  // For non-collaborative boards, further restrict to board owner
+  const authors = board.collaborative
+    ? whitelistedAuthors
+    : [board.pubkey].filter((p) => authorSet.has(p));
   const filter: any = {
     kinds: [39067],
+    authors,
     limit: 200,
   };
-  if (authors) filter.authors = authors;
 
   return new Promise((resolve) => {
     const timeout = setTimeout(() => resolve([]), 15000);
@@ -334,7 +339,9 @@ export async function fetchPinsForBoard(board: Pinboard): Promise<Pin[]> {
       error: () => { clearTimeout(timeout); resolve([]); },
       complete: () => {
         clearTimeout(timeout);
-        const deduped = deduplicateByCoordinate(rawEvents, 39067);
+        // Belt-and-suspenders: client-side whitelist check
+        const filtered = rawEvents.filter((e: any) => authorSet.has(e.pubkey));
+        const deduped = deduplicateByCoordinate(filtered, 39067);
         const pins: Pin[] = [];
         for (const event of deduped) {
           const pin = parsePinEvent(event);

--- a/src/utils/vendorAttestations.ts
+++ b/src/utils/vendorAttestations.ts
@@ -1,5 +1,13 @@
 import { naddrEncode } from "applesauce-core/helpers";
-import { nostrRelays } from "@/config";
+import { nostrRelays, WHITELISTED_PUBKEYS } from "@/config";
+
+// In test mode, use the dynamically injected whitelist
+function getWhitelistedAuthors(): string[] {
+  if (typeof window !== "undefined" && (window as any).__TEST_WHITELIST) {
+    return (window as any).__TEST_WHITELIST;
+  }
+  return WHITELISTED_PUBKEYS;
+}
 
 export interface VendorData {
   name: string;
@@ -38,9 +46,12 @@ export async function fetchVendorAttestations(): Promise<VendorAttestation[]> {
   const allEvents: VendorAttestation[] = [];
 
   // Filter for vendor attestations (kind 30023 with vendor tags)
+  const authors = getWhitelistedAuthors();
+  const authorSet = new Set(authors);
   const filter = {
     kinds: [30023],
     "#t": ["vendor"],
+    authors,
     limit: 100,
   };
 
@@ -97,10 +108,8 @@ export async function fetchVendorAttestations(): Promise<VendorAttestation[]> {
               const [type, subscriptionId, nostrEvent] = message;
 
               if (subscriptionId === "vendor-attestations-sub") {
-                console.log(
-                  `🎯 Found vendor attestation from ${primaryRelay}:`,
-                  nostrEvent,
-                );
+                // Client-side whitelist check (belt-and-suspenders)
+                if (!authorSet.has(nostrEvent.pubkey)) return;
 
                 const vendorAttestation: VendorAttestation = {
                   id: nostrEvent.id,
@@ -242,10 +251,8 @@ export async function fetchVendorAttestations(): Promise<VendorAttestation[]> {
                 const [type, subscriptionId, nostrEvent] = message;
 
                 if (subscriptionId === "vendor-attestations-sub") {
-                  console.log(
-                    `🎯 Found vendor attestation from ${relayUrl}:`,
-                    nostrEvent,
-                  );
+                  // Client-side whitelist check (belt-and-suspenders)
+                  if (!authorSet.has(nostrEvent.pubkey)) return;
 
                   const vendorAttestation: VendorAttestation = {
                     id: nostrEvent.id,


### PR DESCRIPTION
…ttee data (issue #29)

- pinboardEvents.ts: collaborative boards now filter by whitelisted authors at relay level + client-side belt-and-suspenders check (was fetching ALL)
- committeeEvents.ts: fetchMembersForAllCommittees adds authors filter
- committeeEvents.ts: fetchMembersForCommittee adds authors filter
- committeeEvents.ts: fetchOpeningsForAllCommittees adds authors filter
- All three committee fetchers also add client-side pubkey filtering