### PR TITLE
Fix Meetup events not loading

### DIFF
--- a/src/lib/meetup.ts
+++ b/src/lib/meetup.ts
@@ -57,7 +57,7 @@ const EVENTS_QUERY = gql`
       link
       description
       events(
-        first: 0
+        first: 20
         filter: { status: [PAST, ACTIVE] }
         sort: DESC
       ) {


### PR DESCRIPTION
## Summary
- Change GraphQL query `first: 0` to `first: 20` in `src/lib/meetup.ts`
- `first: 0` returns zero events from the Meetup API, which was breaking all event display
- Confirmed via direct API test that `first: 20` returns upcoming and past events correctly

## Root cause
PR #38 set `first: 0` as a "fix" for issue #37 (venue/location display), but this made the query return zero events entirely. The venue fix itself was correct — it just accidentally broke event fetching.

## Test plan
- [x] `next build` passes
- [x] Direct API test confirms events return with `first: 20`
- [ ] After deploy, /calendar and /events show Meetup events

🤖 Generated with [Claude Code](https://claude.com/claude-code)