### PR TITLE
Fix GitHub Pages basePath for subpath deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,6 +35,7 @@ jobs:
           node scripts/post-build.js
         env:
           NEXT_SHARP_REQUIRE_CDN: 1
+          BASE_PATH: /bodarc
 
       - name: Add .nojekyll
         run: touch out/.nojekyll

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: "export",
+  basePath: process.env.BASE_PATH || "",
   images: {
     unoptimized: true,
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,9 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
+  env: {
+    NEXT_PUBLIC_BASE_PATH: process.env.BASE_PATH || "",
+  },
   webpack: (config, { isServer }) => {
     // Enable top-level await support
     config.experiments = {

--- a/scripts/post-build.js
+++ b/scripts/post-build.js
@@ -7,6 +7,7 @@ const path = require('path');
 // It converts /calendar.html to /calendar/index.html so that /calendar works
 
 const outDir = path.join(__dirname, '../out');
+const basePath = process.env.BASE_PATH || '';
 
 // Automatically detect all page HTML files (skip index.html and 404.html)
 const pages = fs.readdirSync(outDir)
@@ -29,26 +30,27 @@ function createCleanUrls() {
       
       // Copy HTML file to index.html in directory
       fs.copyFileSync(sourceFile, targetFile);
-      console.log(`✅ Created clean URL: /${page}/ -> ${targetFile}`);
-      
+      const cleanUrl = `${basePath}/${page}/`;
+      console.log(`✅ Created clean URL: ${cleanUrl} -> ${targetFile}`);
+
       // Also create a redirect from /page.html to /page/ for backward compatibility
       const redirectContent = `<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">
     <title>Redirecting...</title>
-    <meta http-equiv="refresh" content="0; url=/${page}/">
+    <meta http-equiv="refresh" content="0; url=${cleanUrl}">
     <script>
-        window.location.replace('/${page}/' + window.location.search + window.location.hash);
+        window.location.replace('${cleanUrl}' + window.location.search + window.location.hash);
     </script>
 </head>
 <body>
-    <p>Redirecting to <a href="/${page}/">/${page}/</a>...</p>
+    <p>Redirecting to <a href="${cleanUrl}">${cleanUrl}</a>...</p>
 </body>
 </html>`;
       
       fs.writeFileSync(sourceFile, redirectContent);
-      console.log(`✅ Created redirect: /${page}.html -> /${page}/`);
+      console.log(`✅ Created redirect: /${page}.html -> ${cleanUrl}`);
     } else {
       console.warn(`⚠️  Source file not found: ${sourceFile}`);
     }

--- a/src/components/BitcoinLogo.tsx
+++ b/src/components/BitcoinLogo.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Image from "next/image";
-import { config } from "@/config";
+import { config, basePath } from "@/config";
 
 interface BitcoinLogoProps {
   size?: number;
@@ -13,7 +13,8 @@ export default function BitcoinLogo({
   className = "",
   useFallback = false,
 }: BitcoinLogoProps) {
-  const logoSrc = useFallback ? config.site.images.logoFallback : config.site.images.logo;
+  const rawSrc = useFallback ? config.site.images.logoFallback : config.site.images.logo;
+  const logoSrc = rawSrc.startsWith('http') ? rawSrc : `${basePath}${rawSrc}`;
 
   return (
     <div

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -7,7 +7,7 @@ import { useNostr } from "@/contexts/NostrContext";
 import UserProfile from "./UserProfile";
 import NostrLogin from "./NostrLogin";
 import SocialLinks from "./SocialLinks";
-import { config } from "@/config";
+import { config, basePath } from "@/config";
 
 function NavLinks({ currentPath }: { currentPath: string }) {
   return (
@@ -134,19 +134,18 @@ export default function Layout({ children, className }: LayoutProps) {
               className="flex items-center gap-3 text-xl font-black bitcoin-orange uppercase tracking-wider font-archivo-black"
             >
               {config.site.images.logo.startsWith('http') ? (
-                <img 
-                  src={config.site.images.logo} 
+                <img
+                  src={config.site.images.logo}
                   alt={config.site.organization.name}
                   className="h-8 w-auto"
                   onError={(e) => {
-                    // Fallback to logoFallback if URL fails to load
                     const target = e.target as HTMLImageElement;
                     target.src = config.site.images.logoFallback;
                   }}
                 />
               ) : (
-                <img 
-                  src={config.site.images.logo} 
+                <img
+                  src={`${basePath}${config.site.images.logo}`}
                   alt={config.site.organization.name}
                   className="h-8 w-auto"
                 />

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,8 @@
 import configData from '../../config.json';
 
+// Build-time basePath for GitHub Pages subpath hosting (inlined by Next.js)
+export const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
 // Type definitions for the configuration
 export interface SiteConfig {
   title: string;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,11 +1,13 @@
 import { Html, Head, Main, NextScript } from "next/document";
 
+const bp = process.env.NEXT_PUBLIC_BASE_PATH || "";
+
 export default function Document() {
   return (
     <Html lang="en">
       <Head>
-        <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-        <link rel="manifest" href="/manifest.json" />
+        <link rel="apple-touch-icon" href={`${bp}/apple-touch-icon.png`} />
+        <link rel="manifest" href={`${bp}/manifest.json`} />
         <meta name="theme-color" content="#f7931a" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -20,7 +20,7 @@ import {
 } from "../utils/nostrEvents";
 import { PlusIcon } from "../components/Icons";
 import { GetStaticProps, InferGetStaticPropsType } from "next";
-import { WHITELISTED_NPUBS, WHITELISTED_PUBKEYS } from "@/config";
+import { WHITELISTED_NPUBS, WHITELISTED_PUBKEYS, basePath } from "@/config";
 import { config } from "@/config";
 import { useNostr } from "../contexts/NostrContext";
 import { useRef, useCallback } from "react";
@@ -639,7 +639,7 @@ export default function CalendarPage({
               <div className="absolute top-4 left-0 right-0 z-50 flex justify-center">
                 <div className="flex flex-col items-center gap-3 px-6 py-3 bg-white bg-opacity-95 rounded-lg shadow-lg backdrop-blur-sm">
                   <img
-                    src="/bitcoinShaka.jpg"
+                    src={`${basePath}/bitcoinShaka.jpg`}
                     alt="Loading..."
                     className="w-auto h-auto max-w-12 max-h-12 rounded-full animate-spin"
                   />
@@ -724,7 +724,7 @@ export default function CalendarPage({
                   <div className="bitcoin-shaka-loading-overlay mb-8">
                     <div className="bitcoin-shaka-container">
                       <img
-                        src="/bitcoinShaka.jpg"
+                        src={`${basePath}/bitcoinShaka.jpg`}
                         alt="Loading..."
                         className="bitcoin-shaka-spinner"
                       />

--- a/src/pages/committees.tsx
+++ b/src/pages/committees.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
 import Head from "next/head";
-import { config } from "@/config";
+import { config, basePath } from "@/config";
 import { isWhitelisted } from "@/config";
 import { useNostr } from "@/contexts/NostrContext";
 import {
@@ -242,7 +242,7 @@ export default function CommitteesPage() {
         <title>{config.pages.committees.meta.title}</title>
         <meta name="description" content={config.pages.committees.meta.description} />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href={`${basePath}/favicon.ico`} />
       </Head>
 
       <div className="container mx-auto px-4 py-12">

--- a/src/pages/donate.tsx
+++ b/src/pages/donate.tsx
@@ -1,4 +1,4 @@
-import { nostrRelays, WHITELISTED_PUBKEYS } from "@/config";
+import { nostrRelays, WHITELISTED_PUBKEYS, basePath } from "@/config";
 import EventActions from "@/components/EventActions";
 import { pool } from "@/lib/nostr";
 import {
@@ -711,7 +711,7 @@ export default function DonatePage() {
           <h1 className="text-4xl font-bold mb-8 font-archivo-black">Donate</h1>
           <div className="bitcoin-shaka-container">
             <img
-              src="/bitcoinShaka.jpg"
+              src={`${basePath}/bitcoinShaka.jpg`}
               alt="Loading..."
               className="bitcoin-shaka-spinner"
             />

--- a/src/pages/education.tsx
+++ b/src/pages/education.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
 import Head from "next/head";
-import { config, siteConfig } from "@/config";
+import { config, siteConfig, basePath } from "@/config";
 import {
   fetchPinboards,
   fetchFeaturedPins,
@@ -186,7 +186,7 @@ export default function EducationPage() {
       <Head>
         <title>{config.pages.education.meta.title}</title>
         <meta name="description" content={config.pages.education.meta.description} />
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href={`${basePath}/favicon.ico`} />
       </Head>
 
       <div className="container mx-auto px-4 py-12 max-w-6xl">

--- a/src/pages/gallery.tsx
+++ b/src/pages/gallery.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import Head from "next/head";
-import { config, siteConfig } from "@/config";
+import { config, siteConfig, basePath } from "@/config";
 import { streamGalleryImages, GalleryImage, publishGalleryImage, uploadToBlossom } from "@/utils/galleryEvents";
 import { buildDeleteEvent, publishDelete } from "@/utils/pinboardEvents";
 import { useNostr } from "@/contexts/NostrContext";
@@ -41,7 +41,7 @@ export default function GalleryPage() {
       <Head>
         <title>{config.pages.gallery.meta.title}</title>
         <meta name="description" content={config.pages.gallery.meta.description} />
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href={`${basePath}/favicon.ico`} />
       </Head>
 
       <div className="container mx-auto px-4 py-12" data-testid="gallery-page">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Head from "next/head";
 import BitcoinLogo from "@/components/BitcoinLogo";
 import NewsletterForm from "@/components/NewsletterForm";
-import { config, newsletterConfig } from "@/config";
+import { config, newsletterConfig, basePath } from "@/config";
 
 export default function Home() {
   console.log('🏠 Home page - config.images.hero:', config.site.images.hero);
@@ -17,7 +17,7 @@ export default function Home() {
           content={config.pages.home.meta.description}
         />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href={`${basePath}/favicon.ico`} />
       </Head>
 
       {/* Main Content Section - White Background */}


### PR DESCRIPTION
## Summary
- Add `basePath` to `next.config.ts` so Next.js generates `/bodarc/`-prefixed paths
- Expose `NEXT_PUBLIC_BASE_PATH` env var and add `basePath` export to config
- Prefix all static asset references (logo, favicon, bitcoinShaka, apple-touch-icon, manifest) with basePath
- Update `post-build.js` clean URL redirects to account for basePath

## Test plan
- [ ] Verify https://kc-bitcoiners.github.io/bodarc/ loads with logo and images
- [ ] Verify local dev (`npm run dev`) still works without basePath

🤖 Generated with [Claude Code](https://claude.com/claude-code)