### PR TITLE
Add client and location tags to Nostr events (fixes #71)

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -114,6 +114,10 @@ export const getGithubUrl = () => externalLinks.GitHub?.url;
 // Community relay -- first relay from config is the community relay
 export const KC_BITCOINERS_RELAY = nostrRelays[0] || "wss://kcbtc.hzrd149.com/";
 
+// Tags added to all events published from this site
+export const CLIENT_TAG = ["client", "bodarc"] as const;
+export const LOCATION_TAG = ["location", organization.location] as const;
+
 // Social links interface and data (moved from socialLinks.ts)
 export interface SocialLink {
   name: string;

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -20,7 +20,7 @@ import {
 } from "../utils/nostrEvents";
 import { PlusIcon } from "../components/Icons";
 import { GetStaticProps, InferGetStaticPropsType } from "next";
-import { WHITELISTED_NPUBS, WHITELISTED_PUBKEYS, basePath } from "@/config";
+import { WHITELISTED_NPUBS, WHITELISTED_PUBKEYS, basePath, CLIENT_TAG } from "@/config";
 import { config } from "@/config";
 import { useNostr } from "../contexts/NostrContext";
 import { useRef, useCallback } from "react";
@@ -105,7 +105,7 @@ export default function CalendarPage({
     if (!user || !event.rawEvent || user.pubkey !== event.pubkey) return;
     setEvents((prev) => prev.filter((e) => e.id !== event.id));
     const kind = (event.rawEvent as any).kind as number;
-    const unsignedDelete = { kind: 5, content: "Deleted by author", tags: [["e", event.id], ["k", String(kind)]], created_at: Math.floor(Date.now() / 1000) };
+    const unsignedDelete = { kind: 5, content: "Deleted by author", tags: [[...CLIENT_TAG], ["e", event.id], ["k", String(kind)]], created_at: Math.floor(Date.now() / 1000) };
     const signedDelete = await signEvent(unsignedDelete as { kind: number; content: string; tags: string[][]; created_at: number });
     const { pool } = await import("@/lib/nostr");
     const { nostrRelays } = await import("@/config");

--- a/src/utils/committeeEvents.ts
+++ b/src/utils/committeeEvents.ts
@@ -1,5 +1,5 @@
 import { pool } from "@/lib/nostr";
-import { nostrRelays, WHITELISTED_PUBKEYS } from "@/config";
+import { nostrRelays, WHITELISTED_PUBKEYS, CLIENT_TAG, LOCATION_TAG } from "@/config";
 import { buildDeleteEvent, publishDelete } from "@/utils/pinboardEvents";
 import { logger } from "@/utils/logger";
 
@@ -56,7 +56,7 @@ export function buildCommitteeEvent(opts: {
   openings?: number;
   topicTags?: string[];
 }): Record<string, unknown> {
-  const tags: string[][] = [["d", opts.dTag]];
+  const tags: string[][] = [[...CLIENT_TAG], [...LOCATION_TAG], ["d", opts.dTag]];
   if (opts.title) tags.push(["title", opts.title]);
   if (opts.description) tags.push(["description", opts.description]);
   if (opts.image) tags.push(["image", opts.image]);
@@ -83,6 +83,7 @@ export function buildCommitteeMemberEvent(opts: {
   nostrPubkey?: string;
 }): Record<string, unknown> {
   const tags: string[][] = [
+    [...CLIENT_TAG],
     ["a", opts.committeeCoordinate],
     ["d", opts.dTag],
     ["role", opts.role],
@@ -106,6 +107,7 @@ export function buildCommitteeOpeningEvent(opts: {
   description?: string;
 }): Record<string, unknown> {
   const tags: string[][] = [
+    [...CLIENT_TAG],
     ["a", opts.committeeCoordinate],
     ["d", opts.dTag],
     ["title", opts.title],

--- a/src/utils/galleryEvents.ts
+++ b/src/utils/galleryEvents.ts
@@ -1,5 +1,5 @@
 import { pool } from "@/lib/nostr";
-import { WHITELISTED_PUBKEYS, nostrRelays, blossomConfig } from "@/config";
+import { WHITELISTED_PUBKEYS, nostrRelays, blossomConfig, CLIENT_TAG, LOCATION_TAG } from "@/config";
 
 export type SignerFn = (event: { kind: number; content: string; tags: string[][]; created_at: number }) => Promise<Record<string, unknown>>;
 
@@ -153,7 +153,7 @@ export async function publishGalleryImage(
   const imageEvent = {
     kind: 20,
     created_at: Math.floor(Date.now() / 1000),
-    tags: [["imeta", imetaContent]],
+    tags: [[...CLIENT_TAG], [...LOCATION_TAG], ["imeta", imetaContent]],
     content: caption,
   };
   const signedImage = await signer(imageEvent);
@@ -167,6 +167,8 @@ export async function publishGalleryImage(
     kind: 39067,
     created_at: Math.floor(Date.now() / 1000),
     tags: [
+      [...CLIENT_TAG],
+      [...LOCATION_TAG],
       ["A", galleryCoord],
       ["d", `gallery-${Date.now()}`],
       ["e", (signedImage as any).id, nostrRelays[0]],

--- a/src/utils/nostrEvents.ts
+++ b/src/utils/nostrEvents.ts
@@ -1,4 +1,4 @@
-import { getWhitelistFilter, WHITELISTED_NPUBS, WHITELISTED_PUBKEYS, nostrRelays } from "@/config";
+import { getWhitelistFilter, WHITELISTED_NPUBS, WHITELISTED_PUBKEYS, nostrRelays, CLIENT_TAG, LOCATION_TAG } from "@/config";
 import { pool } from "@/lib/nostr";
 import { logger } from "@/utils/logger";
 import {
@@ -225,6 +225,10 @@ export async function publishNostrEvent(
 
     // Convert EventFormData to nostr event format
     const tags: string[][] = [];
+
+    // Add client and location tags
+    tags.push([...CLIENT_TAG]);
+    tags.push([...LOCATION_TAG]);
 
     // Add required tags
     tags.push(["d", dTag]); // Unique identifier

--- a/src/utils/pinboardEvents.ts
+++ b/src/utils/pinboardEvents.ts
@@ -1,5 +1,5 @@
 import { pool } from "@/lib/nostr";
-import { nostrRelays, WHITELISTED_PUBKEYS } from "@/config";
+import { nostrRelays, WHITELISTED_PUBKEYS, CLIENT_TAG, LOCATION_TAG } from "@/config";
 
 // In test mode, use the dynamically injected whitelist
 function getWhitelistedAuthors(): string[] {
@@ -368,6 +368,8 @@ export function buildPinEvent(opts: {
   dTag?: string;
 }): Record<string, unknown> {
   const tags: string[][] = [
+    [...CLIENT_TAG],
+    [...LOCATION_TAG],
     ["A", opts.boardCoordinate],
   ];
 
@@ -415,7 +417,7 @@ export function buildPinboardEvent(opts: {
   description?: string;
   content?: string;
 }): Record<string, unknown> {
-  const tags: string[][] = [["d", opts.dTag]];
+  const tags: string[][] = [[...CLIENT_TAG], ["d", opts.dTag]];
   if (opts.title) tags.push(["title", opts.title]);
   if (opts.description) tags.push(["description", opts.description]);
   return {
@@ -443,6 +445,7 @@ export function buildDeleteEvent(opts: {
   reason?: string;
 }): Record<string, unknown> {
   const tags: string[][] = [
+    [...CLIENT_TAG],
     ["e", opts.eventId],
     ["k", String(opts.eventKind)],
   ];


### PR DESCRIPTION
## Summary
- Add `["client", "bodarc"]` tag to all Nostr events published from the site
- Add `["location", <org location>]` tag pulled from config so forks don't need code changes
- Applied to: calendar events, pins, pinboards, committee/member/opening events, gallery images, and delete requests

## Files changed
- `src/config/index.ts` — export `CLIENT_TAG` and `LOCATION_TAG`
- `src/utils/nostrEvents.ts` — calendar event publishing
- `src/utils/pinboardEvents.ts` — pins, pinboards, and deletes
- `src/utils/committeeEvents.ts` — committees, members, openings
- `src/utils/galleryEvents.ts` — gallery images and pins
- `src/pages/calendar.tsx` — inline delete events

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)