### PR TITLE
Add livestream embed to education page (fixes #53)

### DIFF
--- a/config.json
+++ b/config.json
@@ -40,7 +40,6 @@
           "npub187w4ykkurr3e89mm0rg5p49x6lveqtq0pp0um7qyk6xyrpeerx3s84exkz",
           "npub1nv5c7sj2zxtjv7uayp2q2mneymm39mfp93wjhl5287y6yp6ey02qrsjhcn",
           "npub1yvscx9vrmpcmwcmydrm8lauqdpngum4ne8xmkgc2d4rcaxrx7tkswdwzdu",
-          "npub1sh0cy25xtx0lh6q58kc7rcdl95tzlfs0c6zuv4g4jclx0n7hfx0sghnh3u",
           "npub1eaz6dwsnvwkha5sn5puwwyxjgy26uusundrm684lg3vw4ma5c2jsqarcgz"
       ],
       "whitelistedPubkeys": [
@@ -49,7 +48,6 @@
           "3f9d525adc18e393977b78d140d4a6d7d9902c0f085fcdf804b68c41873919a3",
           "9b298f424a1197267b9d2054056e7926f712ed212c5d2bfe8a3f89a2075923d4",
           "2321831583d871b7636468f67ff78068668e6eb3c9cdbb230a6d478e9866f2ed",
-          "85df822a86599ffbe8143db1e1e1bf2d162fa60fc685c65515963e67cfd7499f",
           "cf45a6ba1363ad7ed213a078e710d24115ae721c9b47bd1ebf4458eaefb4c2a5"
       ],
       "blossom": {

--- a/config.json
+++ b/config.json
@@ -40,7 +40,7 @@
           "npub187w4ykkurr3e89mm0rg5p49x6lveqtq0pp0um7qyk6xyrpeerx3s84exkz",
           "npub1nv5c7sj2zxtjv7uayp2q2mneymm39mfp93wjhl5287y6yp6ey02qrsjhcn",
           "npub1yvscx9vrmpcmwcmydrm8lauqdpngum4ne8xmkgc2d4rcaxrx7tkswdwzdu",
-          "npub12hcytyr8fumy3axde8wgeced523gyp6v6zczqktwuqeaztfc2xzsz3rdp4"
+          "npub19ha7tju4teqp3dmwv4p28wrcy9zd6h6hxkg5mwvjrlfycweazpkse2q0fa"
       ],
       "whitelistedPubkeys": [
           "d70d50091504b992d1838822af245d5f6b3a16b82d917acb7924cef61ed4acee",
@@ -48,7 +48,7 @@
           "3f9d525adc18e393977b78d140d4a6d7d9902c0f085fcdf804b68c41873919a3",
           "9b298f424a1197267b9d2054056e7926f712ed212c5d2bfe8a3f89a2075923d4",
           "2321831583d871b7636468f67ff78068668e6eb3c9cdbb230a6d478e9866f2ed",
-          "55f04590674f3648f4cdc9dc8ce32da2a282074cd0b020596ee033d12d385185"
+          "2dfbe5cb955e4018b76e6542a3b8782144dd5f5735914db9921fd24c3b3d106d"
       ],
       "blossom": {
           "server": "https://blossom.f7z.io"

--- a/config.json
+++ b/config.json
@@ -39,14 +39,16 @@
           "npub1nrswn76gtr6apep95rev06y0cylk2t7utqyw9yn5x7qv8atgn3fscmpv2z",
           "npub187w4ykkurr3e89mm0rg5p49x6lveqtq0pp0um7qyk6xyrpeerx3s84exkz",
           "npub1nv5c7sj2zxtjv7uayp2q2mneymm39mfp93wjhl5287y6yp6ey02qrsjhcn",
-          "npub1yvscx9vrmpcmwcmydrm8lauqdpngum4ne8xmkgc2d4rcaxrx7tkswdwzdu"
+          "npub1yvscx9vrmpcmwcmydrm8lauqdpngum4ne8xmkgc2d4rcaxrx7tkswdwzdu",
+          "npub1sh0cy25xtx0lh6q58kc7rcdl95tzlfs0c6zuv4g4jclx0n7hfx0sghnh3u"
       ],
       "whitelistedPubkeys": [
           "d70d50091504b992d1838822af245d5f6b3a16b82d917acb7924cef61ed4acee",
           "98e0e9fb4858f5d0e425a0f2c7e88fc13f652fdc5808e292743780c3f5689c53",
           "3f9d525adc18e393977b78d140d4a6d7d9902c0f085fcdf804b68c41873919a3",
           "9b298f424a1197267b9d2054056e7926f712ed212c5d2bfe8a3f89a2075923d4",
-          "2321831583d871b7636468f67ff78068668e6eb3c9cdbb230a6d478e9866f2ed"
+          "2321831583d871b7636468f67ff78068668e6eb3c9cdbb230a6d478e9866f2ed",
+          "85df822a86599ffbe8143db1e1e1bf2d162fa60fc685c65515963e67cfd7499f"
       ],
       "blossom": {
           "server": "https://blossom.f7z.io"

--- a/config.json
+++ b/config.json
@@ -40,7 +40,8 @@
           "npub187w4ykkurr3e89mm0rg5p49x6lveqtq0pp0um7qyk6xyrpeerx3s84exkz",
           "npub1nv5c7sj2zxtjv7uayp2q2mneymm39mfp93wjhl5287y6yp6ey02qrsjhcn",
           "npub1yvscx9vrmpcmwcmydrm8lauqdpngum4ne8xmkgc2d4rcaxrx7tkswdwzdu",
-          "npub1sh0cy25xtx0lh6q58kc7rcdl95tzlfs0c6zuv4g4jclx0n7hfx0sghnh3u"
+          "npub1sh0cy25xtx0lh6q58kc7rcdl95tzlfs0c6zuv4g4jclx0n7hfx0sghnh3u",
+          "npub1eaz6dwsnvwkha5sn5puwwyxjgy26uusundrm684lg3vw4ma5c2jsqarcgz"
       ],
       "whitelistedPubkeys": [
           "d70d50091504b992d1838822af245d5f6b3a16b82d917acb7924cef61ed4acee",
@@ -48,7 +49,8 @@
           "3f9d525adc18e393977b78d140d4a6d7d9902c0f085fcdf804b68c41873919a3",
           "9b298f424a1197267b9d2054056e7926f712ed212c5d2bfe8a3f89a2075923d4",
           "2321831583d871b7636468f67ff78068668e6eb3c9cdbb230a6d478e9866f2ed",
-          "85df822a86599ffbe8143db1e1e1bf2d162fa60fc685c65515963e67cfd7499f"
+          "85df822a86599ffbe8143db1e1e1bf2d162fa60fc685c65515963e67cfd7499f",
+          "cf45a6ba1363ad7ed213a078e710d24115ae721c9b47bd1ebf4458eaefb4c2a5"
       ],
       "blossom": {
           "server": "https://blossom.f7z.io"

--- a/config.json
+++ b/config.json
@@ -40,7 +40,7 @@
           "npub187w4ykkurr3e89mm0rg5p49x6lveqtq0pp0um7qyk6xyrpeerx3s84exkz",
           "npub1nv5c7sj2zxtjv7uayp2q2mneymm39mfp93wjhl5287y6yp6ey02qrsjhcn",
           "npub1yvscx9vrmpcmwcmydrm8lauqdpngum4ne8xmkgc2d4rcaxrx7tkswdwzdu",
-          "npub1eaz6dwsnvwkha5sn5puwwyxjgy26uusundrm684lg3vw4ma5c2jsqarcgz"
+          "npub12hcytyr8fumy3axde8wgeced523gyp6v6zczqktwuqeaztfc2xzsz3rdp4"
       ],
       "whitelistedPubkeys": [
           "d70d50091504b992d1838822af245d5f6b3a16b82d917acb7924cef61ed4acee",
@@ -48,7 +48,7 @@
           "3f9d525adc18e393977b78d140d4a6d7d9902c0f085fcdf804b68c41873919a3",
           "9b298f424a1197267b9d2054056e7926f712ed212c5d2bfe8a3f89a2075923d4",
           "2321831583d871b7636468f67ff78068668e6eb3c9cdbb230a6d478e9866f2ed",
-          "cf45a6ba1363ad7ed213a078e710d24115ae721c9b47bd1ebf4458eaefb4c2a5"
+          "55f04590674f3648f4cdc9dc8ce32da2a282074cd0b020596ee033d12d385185"
       ],
       "blossom": {
           "server": "https://blossom.f7z.io"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "clsx": "^2.1.1",
     "graphql": "^16.12.0",
     "graphql-request": "^7.4.0",
+    "hls.js": "^1.6.16",
     "leaflet": "^1.9.4",
     "next": "15.3.4",
     "qrcode": "^1.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       graphql-request:
         specifier: ^7.4.0
         version: 7.4.0(graphql@16.12.0)
+      hls.js:
+        specifier: ^1.6.16
+        version: 1.6.16
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
@@ -74,7 +77,7 @@ importers:
         version: 7.8.2
       window.nostrdb.js:
         specifier: ^0.5.1
-        version: 0.5.1(hono@4.11.3)(typescript@5.9.3)(zod@4.3.4)
+        version: 0.5.1(hono@4.11.3)(typescript@5.9.3)(zod@3.25.76)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.3
@@ -325,105 +328,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -506,28 +493,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.3.4':
     resolution: {integrity: sha512-wFyZ7X470YJQtpKot4xCY3gpdn8lE9nTlldG07/kJYexCUpX1piX+MBfZdvulo+t1yADFVEuzFfVHfklfEx8kw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.3.4':
     resolution: {integrity: sha512-gEbH9rv9o7I12qPyvZNVTyP/PWKqOp8clvnoYZQiX800KkqsaJZuOXkWgMa7ANCCh/oEN2ZQheh3yH8/kWPSEg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.3.4':
     resolution: {integrity: sha512-Cf8sr0ufuC/nu/yQ76AnarbSAXcwG/wj+1xFPNbyNo8ltA6kw5d5YqO8kQuwVIxk13SBdtgXrNyom3ZosHAy4A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.3.4':
     resolution: {integrity: sha512-ay5+qADDN3rwRbRpEhTOreOn1OyJIXS60tg9WMYTWCy3fB6rGoyjLVxc4dR9PYjEdR2iDYsaF5h03NA+XuYPQQ==}
@@ -641,42 +624,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
@@ -775,28 +752,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -989,49 +962,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1868,6 +1833,9 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hls.js@1.6.16:
+    resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
+
   hono@4.11.3:
     resolution: {integrity: sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==}
     engines: {node: '>=16.9.0'}
@@ -2188,56 +2156,48 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -3678,28 +3638,6 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - hono
-      - supports-color
-
-  '@modelcontextprotocol/sdk@1.25.1(hono@4.11.3)(zod@4.3.4)':
-    dependencies:
-      '@hono/node-server': 1.19.7(hono@4.11.3)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
-      content-type: 1.0.5
-      cors: 2.8.5
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 7.5.1(express@5.2.1)
-      jose: 6.1.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.3.4
-      zod-to-json-schema: 3.25.1(zod@4.3.4)
     transitivePeerDependencies:
       - hono
       - supports-color
@@ -5303,6 +5241,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  hls.js@1.6.16: {}
 
   hono@4.11.3: {}
 
@@ -6948,10 +6888,10 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  window.nostrdb.js@0.5.1(hono@4.11.3)(typescript@5.9.3)(zod@4.3.4):
+  window.nostrdb.js@0.5.1(hono@4.11.3)(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@contextvm/sdk': 0.1.48(hono@4.11.3)(typescript@5.9.3)
-      '@modelcontextprotocol/sdk': 1.25.1(hono@4.11.3)(zod@4.3.4)
+      '@modelcontextprotocol/sdk': 1.25.1(hono@4.11.3)(zod@3.25.76)
       applesauce-extra: 4.1.0(typescript@5.9.3)
       applesauce-loaders: 4.2.0(typescript@5.9.3)
       applesauce-relay: 4.4.2(typescript@5.9.3)
@@ -7004,10 +6944,6 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod-to-json-schema@3.25.1(zod@4.3.4):
-    dependencies:
-      zod: 4.3.4
 
   zod-validation-error@4.0.2(zod@4.3.4):
     dependencies:

--- a/src/components/LivestreamPlayer.tsx
+++ b/src/components/LivestreamPlayer.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useRef } from "react";
+import Hls from "hls.js";
+import { Livestream } from "@/utils/livestreams";
+
+interface LivestreamPlayerProps {
+  streams: Livestream[];
+}
+
+export default function LivestreamPlayer({ streams }: LivestreamPlayerProps) {
+  if (streams.length === 0) return null;
+
+  return (
+    <div className="mb-8">
+      <div className="flex items-center gap-2 mb-4">
+        <span className="relative flex h-3 w-3">
+          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-500 opacity-75" />
+          <span className="relative inline-flex rounded-full h-3 w-3 bg-red-600" />
+        </span>
+        <h2 className="text-xl font-bold font-archivo-black">Live Now</h2>
+      </div>
+      <div className="grid gap-4">
+        {streams.map((stream) => (
+          <StreamCard key={stream.id} stream={stream} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StreamCard({ stream }: { stream: Livestream }) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const hlsRef = useRef<Hls | null>(null);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || !stream.streamingUrl) return;
+
+    if (Hls.isSupported()) {
+      const hls = new Hls({
+        enableWorker: true,
+        lowLatencyMode: true,
+      });
+      hls.loadSource(stream.streamingUrl);
+      hls.attachMedia(video);
+      hls.on(Hls.Events.MANIFEST_PARSED, () => {
+        video.play().catch(() => {});
+      });
+      hlsRef.current = hls;
+
+      return () => {
+        hls.destroy();
+        hlsRef.current = null;
+      };
+    } else if (video.canPlayType("application/vnd.apple.mpegurl")) {
+      // Native HLS support (Safari)
+      video.src = stream.streamingUrl;
+      video.addEventListener("loadedmetadata", () => {
+        video.play().catch(() => {});
+      });
+    }
+  }, [stream.streamingUrl]);
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-xl overflow-hidden shadow-sm">
+      <div className="flex flex-col md:flex-row">
+        {/* Video player */}
+        <div className="md:w-2/3 bg-black">
+          <video
+            ref={videoRef}
+            className="w-full aspect-video"
+            controls
+            playsInline
+            muted
+            poster={stream.image || undefined}
+          />
+        </div>
+
+        {/* Stream info */}
+        <div className="md:w-1/3 p-4 flex flex-col justify-between">
+          <div>
+            <div className="flex items-center gap-2 mb-2">
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-semibold bg-red-100 text-red-700 rounded-full">
+                <span className="h-1.5 w-1.5 bg-red-600 rounded-full animate-pulse" />
+                LIVE
+              </span>
+            </div>
+            <h3 className="font-bold text-lg mb-1">{stream.title}</h3>
+            {stream.summary && (
+              <p className="text-gray-600 text-sm line-clamp-3">
+                {stream.summary}
+              </p>
+            )}
+          </div>
+
+          <div className="mt-4 text-xs text-gray-400">
+            Host: {stream.host.pubkey.slice(0, 12)}...
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/education.tsx
+++ b/src/pages/education.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useCallback } from "react";
 import Head from "next/head";
 import { config, siteConfig, basePath } from "@/config";
+import { fetchLivestreams, Livestream } from "@/utils/livestreams";
+import LivestreamPlayer from "@/components/LivestreamPlayer";
 import {
   fetchPinboards,
   fetchFeaturedPins,
@@ -90,6 +92,7 @@ export default function EducationPage() {
   const [showAddPin, setShowAddPin] = useState(false);
   const [editPin, setEditPin] = useState<Pin | null>(null);
   const [sortBy, setSortBy] = useState<"date" | "title">("date");
+  const [livestreams, setLivestreams] = useState<Livestream[]>([]);
 
   const loadAll = useCallback(async () => {
     setLoadingFeatured(true);
@@ -107,6 +110,16 @@ export default function EducationPage() {
   }, []);
 
   useEffect(() => { loadAll(); }, [loadAll]);
+
+  // Fetch active livestreams and poll every 60s
+  useEffect(() => {
+    const loadStreams = () => {
+      fetchLivestreams().then(setLivestreams).catch(() => {});
+    };
+    loadStreams();
+    const interval = setInterval(loadStreams, 60000);
+    return () => clearInterval(interval);
+  }, []);
 
   const loadPins = useCallback(async (board: Pinboard) => {
     setLoadingPins(true);
@@ -199,6 +212,9 @@ export default function EducationPage() {
             Curated collections of educational content, articles, links, and media bitcoin.
           </p>
         </div>
+
+        {/* Active Livestreams */}
+        <LivestreamPlayer streams={livestreams} />
 
         {/* Tab Navigation */}
         <div className="flex justify-center gap-4 mb-10">

--- a/src/utils/livestreams.ts
+++ b/src/utils/livestreams.ts
@@ -63,14 +63,13 @@ export async function fetchLivestreams(): Promise<Livestream[]> {
         complete: () => {
           clearTimeout(timeout);
 
-          // Deduplicate by d tag (keep most recent per pubkey)
+          // Deduplicate by d tag (keep most recent)
           const seen = new Map<string, any>();
           for (const e of rawEvents) {
             const d = getTag(e.tags, "d");
-            const key = `${e.pubkey}:${d}`;
-            const existing = seen.get(key);
+            const existing = seen.get(d);
             if (!existing || e.created_at > existing.created_at) {
-              seen.set(key, e);
+              seen.set(d, e);
             }
           }
 

--- a/src/utils/livestreams.ts
+++ b/src/utils/livestreams.ts
@@ -1,0 +1,83 @@
+import { pool } from "@/lib/nostr";
+import { nostrRelays, WHITELISTED_PUBKEYS } from "@/config";
+
+export interface Livestream {
+  id: string;
+  pubkey: string;
+  dTag: string;
+  title: string;
+  summary: string;
+  image: string;
+  streamingUrl: string;
+  status: string;
+  starts: string;
+  recording: string;
+  host: { pubkey: string; relay?: string; role?: string };
+  created_at: number;
+}
+
+function getTag(tags: string[][], name: string): string {
+  return tags.find((t) => t[0] === name)?.[1] || "";
+}
+
+function parseLivestream(event: any): Livestream {
+  const hostTag = event.tags.find((t: string[]) => t[0] === "p");
+  return {
+    id: event.id,
+    pubkey: event.pubkey,
+    dTag: getTag(event.tags, "d"),
+    title: getTag(event.tags, "title"),
+    summary: getTag(event.tags, "summary"),
+    image: getTag(event.tags, "image"),
+    streamingUrl: getTag(event.tags, "streaming"),
+    status: getTag(event.tags, "status"),
+    starts: getTag(event.tags, "starts"),
+    recording: getTag(event.tags, "recording"),
+    host: hostTag
+      ? { pubkey: hostTag[1], relay: hostTag[2], role: hostTag[3] }
+      : { pubkey: event.pubkey },
+    created_at: event.created_at,
+  };
+}
+
+export async function fetchLivestreams(): Promise<Livestream[]> {
+  const relays = nostrRelays;
+  const authors = WHITELISTED_PUBKEYS;
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => resolve([]), 15000);
+    const rawEvents: any[] = [];
+
+    pool
+      .request(relays, {
+        kinds: [30311],
+        authors,
+        "#status": ["live"],
+        limit: 20,
+      })
+      .subscribe({
+        next: (event) => rawEvents.push(event),
+        error: () => {
+          clearTimeout(timeout);
+          resolve([]);
+        },
+        complete: () => {
+          clearTimeout(timeout);
+          // Deduplicate by d tag (keep most recent)
+          const seen = new Map<string, any>();
+          for (const e of rawEvents) {
+            const d = getTag(e.tags, "d");
+            const existing = seen.get(d);
+            if (!existing || e.created_at > existing.created_at) {
+              seen.set(d, e);
+            }
+          }
+          resolve(
+            Array.from(seen.values())
+              .map(parseLivestream)
+              .sort((a, b) => b.created_at - a.created_at)
+          );
+        },
+      });
+  });
+}

--- a/src/utils/livestreams.ts
+++ b/src/utils/livestreams.ts
@@ -77,7 +77,7 @@ export async function fetchLivestreams(): Promise<Livestream[]> {
             .filter((s) => s.status === "live")
             .sort((a, b) => b.created_at - a.created_at);
 
-          resolve(liveStreams);
+          resolve(liveStreams.slice(0, 1));
         },
       });
   });

--- a/src/utils/livestreams.ts
+++ b/src/utils/livestreams.ts
@@ -42,7 +42,6 @@ function parseLivestream(event: any): Livestream {
 
 export async function fetchLivestreams(): Promise<Livestream[]> {
   const relays = nostrRelays;
-  const authors = WHITELISTED_PUBKEYS;
 
   return new Promise((resolve) => {
     const timeout = setTimeout(() => resolve([]), 15000);
@@ -51,7 +50,7 @@ export async function fetchLivestreams(): Promise<Livestream[]> {
     pool
       .request(relays, {
         kinds: [30311],
-        authors,
+        "#p": WHITELISTED_PUBKEYS,
         limit: 50,
       })
       .subscribe({

--- a/src/utils/livestreams.ts
+++ b/src/utils/livestreams.ts
@@ -52,8 +52,7 @@ export async function fetchLivestreams(): Promise<Livestream[]> {
       .request(relays, {
         kinds: [30311],
         authors,
-        "#status": ["live"],
-        limit: 20,
+        limit: 50,
       })
       .subscribe({
         next: (event) => rawEvents.push(event),
@@ -63,20 +62,24 @@ export async function fetchLivestreams(): Promise<Livestream[]> {
         },
         complete: () => {
           clearTimeout(timeout);
-          // Deduplicate by d tag (keep most recent)
+
+          // Deduplicate by d tag (keep most recent per pubkey)
           const seen = new Map<string, any>();
           for (const e of rawEvents) {
             const d = getTag(e.tags, "d");
-            const existing = seen.get(d);
+            const key = `${e.pubkey}:${d}`;
+            const existing = seen.get(key);
             if (!existing || e.created_at > existing.created_at) {
-              seen.set(d, e);
+              seen.set(key, e);
             }
           }
-          resolve(
-            Array.from(seen.values())
-              .map(parseLivestream)
-              .sort((a, b) => b.created_at - a.created_at)
-          );
+
+          const liveStreams = Array.from(seen.values())
+            .map(parseLivestream)
+            .filter((s) => s.status === "live")
+            .sort((a, b) => b.created_at - a.created_at);
+
+          resolve(liveStreams);
         },
       });
   });


### PR DESCRIPTION
## Summary
- Fetch active NIP-53 live events (kind 30311) from whitelisted pubkeys
- Display active livestreams with HLS video player on the education page
- Polls every 60s for live status — streams appear/disappear automatically
- Added test pubkey (vapor funk radio) to whitelist for testing

## Files changed
- `config.json` — added test pubkey to whitelist
- `src/utils/livestreams.ts` — fetch/parse NIP-53 live events
- `src/components/LivestreamPlayer.tsx` — HLS player + stream card UI
- `src/pages/education.tsx` — livestream section above tab navigation
- `package.json` — added hls.js

## Test plan
- [ ] Visit /education, should see "24/7 Vapor Funk Radio" livestream
- [ ] Video player should load and play the HLS stream
- [ ] Verify stream disappears when status changes to "ended"
- [ ] Remove test pubkey from whitelist, verify stream disappears

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)