### PR TITLE
Add CLAUDE.md agent docs + rewrite README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,192 @@
+# CLAUDE.md — Agent Reference for bodarc
+
+## Project Overview
+Bodarc is the KC Bitcoiners community website — a statically-exported Next.js app that uses Nostr as its data layer. Content (events, education pins, gallery images, committees) is stored on Nostr relays and rendered client-side. The site deploys to three targets simultaneously on every master push.
+
+## Tech Stack
+- **Framework**: Next.js 15 (Pages Router), React 19, TypeScript
+- **Styling**: Tailwind CSS
+- **Nostr**: applesauce-core, applesauce-relay, applesauce-loaders
+- **Crypto**: @noble/curves (Schnorr), @scure/base (bech32)
+- **Testing**: Vitest (unit), Playwright (E2E, Chromium only)
+- **Package manager**: pnpm only (do not use npm or yarn)
+- **Build**: Static export (`output: "export"` in next.config.ts)
+
+## Commands
+```bash
+pnpm dev          # Start dev server (turbopack) on localhost:3000
+pnpm build        # Production static export to out/
+pnpm start        # Serve production build (requires non-export config)
+pnpm lint         # ESLint via next lint
+pnpm format       # Prettier format all files
+pnpm test         # Vitest unit tests (no server needed)
+pnpm test:watch   # Vitest in watch mode
+```
+
+Playwright tests run via `npx playwright test` (not an npm script).
+
+## Testing
+
+### Unit Tests
+- Runner: Vitest (`vitest.config.ts`)
+- Location: `tests/**/*.test.ts`
+- Run: `pnpm test`
+- Currently covers calendar utilities; no server needed
+
+### E2E Tests (Playwright)
+- Config: `playwright.config.ts`
+- Browser: Chromium only
+- Base URL: `http://localhost:3000` (or `E2E_BASE_URL` env var)
+- Auto-starts dev server: `NEXT_DIST_DIR=/tmp/bodarc-next pnpm dev`
+
+#### Test Tags
+| Tag | Purpose |
+|-----|---------|
+| `@login` | Login/auth flow |
+| `@calendar` | Calendar page |
+| `@committees` | Committees page |
+| `@education` | Education page |
+| `@gallery` | Gallery page |
+| `@whitelist` | Requires relay CRUD with whitelisted nsec |
+
+#### @whitelist Tests
+These tests publish real events to Nostr relays. They:
+- Generate a fresh keypair per run via `tests/global-setup.ts`
+- Inject a NIP-07 `window.nostr` mock via `injectNostrExtension(page)`
+- Store test keys in `.test-keys.json` (gitignored, cleaned up after run)
+- Override the app's whitelist via `window.__TEST_WHITELIST`
+- Are **excluded in CI** (`grepInvert: [/@whitelist/]`)
+- Can be flaky due to relay latency — use `waitForPinToAppear()` which retries with reloads
+
+#### CI vs Local
+| | Local | CI (`CI=1`) |
+|---|---|---|
+| Retries | 0 | 2 |
+| Workers | auto | 1 |
+| @whitelist | included | excluded |
+
+#### Running Specific Tests
+```bash
+npx playwright test                           # All tests
+npx playwright test -g "add an Article"       # By name pattern
+npx playwright test --grep @education         # By tag
+E2E_BASE_URL=https://kcbitcoiners.com npx playwright test --grep @calendar  # Against prod
+```
+
+#### Key Test Helpers (`tests/helpers.ts`)
+- `injectNostrExtension(page)` — injects NIP-07 mock with test key signing, pre-populates localStorage, sets `__TEST_WHITELIST`. Must be called before `page.goto()`.
+- `getTestKeys()` — returns `{ privkeyHex, pubkeyHex, npub, nsec }` for current test run
+- `loginWithTestAccount(page)` — logs in via "Use Existing Key" flow with test nsec
+
+#### Common Test Patterns
+- **Dropdown menus**: Use `locator.evaluate(el => el.click())` for off-viewport menu items (absolutely positioned dropdowns)
+- **Waiting for relay propagation**: Use `waitForPinToAppear(page, title)` which reloads with retries
+- **Publishing events**: Tests sign events server-side via `__nostrSign` exposed function, then publish to real relays
+
+### Remote Testing
+```bash
+# Test against production
+E2E_BASE_URL=https://kcbitcoiners.com npx playwright test --grep @calendar
+
+# Test against dev
+E2E_BASE_URL=https://dev.kcbitcoiners.com npx playwright test --grep @education
+
+# Test against GitHub Pages
+E2E_BASE_URL=https://kc-bitcoiners.github.io/bodarc npx playwright test --grep @login
+```
+Note: @whitelist tests won't work against remote (test keys aren't whitelisted there).
+
+## Architecture
+
+### Pages (`src/pages/`)
+- `index.tsx` — Home page
+- `calendar.tsx` — Event calendar with Meetup integration
+- `events.tsx` — Event listings
+- `education.tsx` — Educational content pinboard (largest page, ~1200 lines)
+- `shop.tsx` — Bitcoin vendor directory with map
+- `gallery.tsx` — Photo gallery with Blossom upload
+- `committees.tsx` — Committee management
+- `donate.tsx` — Donation/zap goals page
+
+### Data Layer
+All user-generated content lives on Nostr relays, fetched client-side:
+- **Pinboards** (kind 30067) — boards that hold pins
+- **Pins** (kind 39067) — links to resources, events, articles
+- **Articles** (kind 30023) — long-form markdown content (NIP-23)
+- **Profiles** (kind 0) — user metadata
+- **Calendar events** (kind 31923) — NIP-52 calendar events
+- **Committee events** (kinds 39068-39071) — committees, members, openings
+- **Gallery images** — uploaded via Blossom protocol, referenced in kind 20 events
+
+### Key Files
+- `config.json` — Single source of truth for site config (relays, whitelist, page metadata, API endpoints)
+- `src/config/` — TypeScript types and helpers around config.json
+- `src/lib/nostr.ts` — RelayPool setup, event store, loader initialization
+- `src/contexts/NostrContext.tsx` — NIP-07 auth context (getPublicKey, signEvent)
+- `src/utils/pinboardEvents.ts` — Pinboard/pin CRUD operations
+- `src/utils/newsletterEvents.ts` — Article (kind 30023) building/publishing
+- `src/utils/committeeEvents.ts` — Committee event operations
+- `src/utils/nostrEvents.ts` — Calendar event operations
+- `src/utils/bech32.ts` — npub/nsec/naddr encoding
+- `src/components/EventActions.tsx` — Context menu for Nostr events (share, raw data, delete)
+
+### Event Flow
+1. User authenticates via NIP-07 browser extension (window.nostr)
+2. App builds unsigned event with proper kind/tags
+3. Extension signs event (or test helper in E2E)
+4. Signed event published to all configured relays via pool.publish()
+5. Events propagate through relay network
+6. Client subscribes and renders new data
+
+### Configuration
+`config.json` contains:
+- `site` — Organization name, location, coordinates, external links, images
+- `nostr` — Relay URLs, whitelisted npubs/pubkeys, Blossom server
+- `pages` — Per-page config (metadata, API endpoints, UI settings)
+- `newsletter` — Newsletter signup form text
+
+## Deployment
+
+All deployments trigger on push to `master`. The site is a static export — no server-side code.
+
+### 1. GitHub Pages (`deploy-pages.yml`)
+- URL: https://kc-bitcoiners.github.io/bodarc
+- Builds with `BASE_PATH=/bodarc` for subpath hosting
+- Post-build: `scripts/post-build.js` creates clean URLs (page.html → page/index.html)
+- Adds `.nojekyll` to prevent Jekyll processing
+
+### 2. S3 + CloudFront (`staticS3.yml`)
+- **Production**: kcbitcoiners.com
+- **Development**: dev.kcbitcoiners.com
+- Triggers: master/dev/deployBug pushes, scheduled (Mon/Wed/Sat), manual dispatch
+- Also publishes to Nostr/Blossom CDN via nsite-action
+- CloudFront invalidation after each deploy
+- AWS credentials via OIDC role assumption (no long-lived keys)
+
+### 3. Nostr/Blossom (`staticS3.yml`, nsite-action)
+- Publishes static assets to decentralized CDN
+- Relays: relay.nsite.lol, relay.damus.io
+- CDN servers: cdn.hzrd149.com, cdn.sovbit.host, blossom.band
+- Config: `.nsite/config.json`
+- Uses NBUNKSEC secret for Nostr authentication
+
+### 4. DNS (`dns.yml`)
+- Terraform + Dreamhost provider
+- Manages A record for relay.kcbitcoiners.com (139.144.226.121)
+- Only triggers on changes to `terraform/` directory
+
+## Key Patterns
+
+- **Nostr events are immutable**: Edits use replaceable events (kind 30000+ with d-tag)
+- **Whitelist gating**: Only pubkeys in `config.json` → `nostr.whitelistedPubkeys` can publish
+- **pnpm only**: Never use npm or yarn
+- **Static export**: No API routes, no server-side rendering. All data fetched client-side from Nostr relays
+- **`nostr-tools` not available**: pnpm doesn't hoist it; custom implementations in `src/utils/bech32.ts`
+- **Turbopack dev**: Dev server uses `--turbopack` flag; some ESM modules need lazy-loading to avoid resolution issues
+- **Image handling**: Gallery images uploaded to Blossom server (blossom.f7z.io), referenced by URL in events
+- **Tailwind Typography**: Used for rendering markdown content (ReactMarkdown + prose classes)
+
+## Repository
+- GitHub: KC-Bitcoiners/bodarc
+- Default branch: master
+- PR branches: feature/XX-description pattern

--- a/README.md
+++ b/README.md
@@ -1,42 +1,162 @@
-![Bodarc Logo](public/repository-open-graph-template.png)
+# KC Bitcoiners — bodarc
 
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/pages/api-reference/create-next-app).
+The community website for [KC Bitcoiners](https://kcbitcoiners.com), a Bitcoin-only meetup group in Kansas City. Built with Next.js as a fully static site that uses the Nostr protocol as its data layer for events, educational content, galleries, and committee management.
+
+## Tech Stack
+
+- **[Next.js 15](https://nextjs.org)** — React framework with static export
+- **[React 19](https://react.dev)** — UI library
+- **[Tailwind CSS](https://tailwindcss.com)** — Utility-first styling
+- **[Nostr](https://nostr.com)** — Decentralized data layer via [applesauce](https://github.com/hzrd149/applesauce) libraries
+- **[Playwright](https://playwright.dev)** — End-to-end testing
+- **[Vitest](https://vitest.dev)** — Unit testing
 
 ## Getting Started
 
-First, run the development server:
+### Prerequisites
+
+- Node.js 20+
+- pnpm (`corepack enable` or `npm install -g pnpm`)
+
+### Install & Run
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
+pnpm install
 pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) in your browser.
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+### Build
 
-[API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+```bash
+pnpm build
+```
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) instead of React pages.
+Static files are output to `out/`. A post-build script (`scripts/post-build.js`) creates clean URL structures for static hosting.
 
-This project uses [`next/font`](https://nextjs.org/docs/pages/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Project Structure
 
-## Learn More
+```
+bodarc/
+├── config.json            # Site configuration (relays, whitelist, page metadata)
+├── next.config.ts         # Next.js config (static export, basePath support)
+├── src/
+│   ├── pages/             # Page components (Next.js Pages Router)
+│   ├── components/        # Reusable UI components
+│   ├── contexts/          # React contexts (NostrContext for auth)
+│   ├── utils/             # Event builders, crypto helpers, API clients
+│   ├── lib/               # Nostr pool/event store setup
+│   └── styles/            # Global styles
+├── tests/                 # Playwright E2E + Vitest unit tests
+├── scripts/               # Build scripts (post-build clean URLs)
+├── terraform/             # DNS management (Dreamhost)
+├── .github/workflows/     # CI/CD pipelines
+└── .nsite/                # Nostr site deployment config
+```
 
-To learn more about Next.js, take a look at the following resources:
+## Testing
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn-pages-router) - an interactive Next.js tutorial.
+### Unit Tests
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+```bash
+pnpm test              # Run once
+pnpm test:watch        # Watch mode
+```
 
-## Deploy on Vercel
+No dev server required. Tests live in `tests/**/*.test.ts`.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+### E2E Tests (Playwright)
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/pages/building-your-application/deploying) for more details.
+```bash
+npx playwright test                        # All tests
+npx playwright test --grep @education      # Education tests only
+npx playwright test -g "add a Link"        # By test name
+```
+
+Playwright auto-starts the dev server on port 3000. Tests run in Chromium.
+
+#### Test Tags
+
+Tests are organized by page and capability using tags:
+
+- `@login` — Authentication flow
+- `@calendar` — Calendar page
+- `@committees` — Committees CRUD
+- `@education` — Education resource browsing
+- `@gallery` — Photo gallery
+- `@whitelist` — Tests that publish to live Nostr relays (require whitelisted keys)
+
+#### @whitelist Tests
+
+Tests tagged `@whitelist` publish real events to Nostr relays. They generate a fresh keypair each run and inject a mock NIP-07 browser extension. These tests are excluded in CI environments since they depend on relay availability and the test keys aren't whitelisted in production config.
+
+#### Testing Against Live Sites
+
+```bash
+E2E_BASE_URL=https://kcbitcoiners.com npx playwright test --grep @calendar
+E2E_BASE_URL=https://dev.kcbitcoiners.com npx playwright test --grep @education
+```
+
+Note: @whitelist tests cannot run against remote sites (test keys aren't whitelisted).
+
+## Configuration
+
+`config.json` is the single source of truth for the site:
+
+- **`site`** — Organization name, location, external links, image paths
+- **`nostr`** — Relay URLs, whitelisted pubkeys, Blossom server URL
+- **`pages`** — Per-page settings (metadata, API endpoints, UI configuration)
+- **`newsletter`** — Newsletter signup form text
+
+No environment files are needed for local development.
+
+## Deployment
+
+The site is a static export — no server-side code. Every push to `master` triggers three simultaneous deployments:
+
+### Production — kcbitcoiners.com
+
+S3 + CloudFront via GitHub Actions (`staticS3.yml`):
+- Static files synced to S3 bucket
+- CloudFront cache invalidation
+- Also publishes to Nostr/Blossom decentralized CDN
+
+### Development — dev.kcbitcoiners.com
+
+Same pipeline, different S3 bucket. Triggered by pushes to `dev` branch or manual dispatch.
+
+### GitHub Pages — kc-bitcoiners.github.io/bodarc
+
+Built with `BASE_PATH=/bodarc` for subpath hosting (`deploy-pages.yml`). Post-build script creates clean URL structure.
+
+### DNS Management
+
+Terraform + Dreamhost provider (`dns.yml`) manages the `relay.kcbitcoiners.com` A record. Only triggers on changes to the `terraform/` directory.
+
+## How Nostr Data Works
+
+The app uses Nostr relays as its database. All user-generated content (events, resources, gallery photos, committee data) is stored as Nostr events:
+
+| Kind | Purpose | NIP |
+|------|---------|-----|
+| 0 | User profiles | NIP-01 |
+| 30023 | Long-form articles | NIP-23 |
+| 30067 | Pinboards (resource collections) | Community |
+| 39067 | Pins (resource links) | Community |
+| 31923 | Calendar events | NIP-52 |
+| 39068-39071 | Committee structures | Community |
+
+Users authenticate via a NIP-07 compatible browser extension (e.g., [nos2x](https://github.com/fiatjaf/nos2x), [Alby](https://getalby.com)). Publishing is restricted to whitelisted pubkeys defined in `config.json`.
+
+## Contributing
+
+1. Create a feature branch from `master`: `git checkout -b feature/XX-description`
+2. Make changes and test locally
+3. Run `pnpm lint` and `pnpm test` before pushing
+4. Open a PR against `master`
+5. Squash merge preferred for clean history
+
+## License
+
+All rights reserved. KC Bitcoiners community project.


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` — comprehensive agent/AI reference covering testing, architecture, deployment pipelines, Nostr data model, and key patterns
- Replace default Next.js `README.md` boilerplate with real project documentation covering setup, testing guide, configuration, deployment overview, and contributing guidelines

## Test plan
- [x] `pnpm build` passes
- [x] No merge conflicts with master
- [ ] Review CLAUDE.md for accuracy against codebase
- [ ] Review README.md for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)