### PR TITLE
fix(security): restrict postMessage origin and remove debug logs

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -114,10 +114,6 @@ export default function Layout({ children, className }: LayoutProps) {
   const router = useRouter();
   const currentPath = router.pathname;
 
-  // Debug logging
-  console.log('🔧 Layout - config.site.images.logo:', config.site.images.logo);
-  console.log('🔧 Layout - config.site.organization.name:', config.site.organization.name);
-
   const toggleMobileMenu = () => {
     setMobileMenuOpen(!mobileMenuOpen);
   };

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -89,7 +89,7 @@ export default function CalendarPage({
       ) {
         chatIframeRef.current.contentWindow?.postMessage(
           { type: "cornychat-signin", nsec: user.privateKey },
-          "*",
+          "https://cornychat.com",
         );
       }
     },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,9 +5,6 @@ import NewsletterForm from "@/components/NewsletterForm";
 import { config, newsletterConfig, basePath } from "@/config";
 
 export default function Home() {
-  console.log('🏠 Home page - config.images.hero:', config.site.images.hero);
-  console.log('🏠 Home page - config.site.organization.name:', config.site.organization.name);
-  
   return (
     <>
       <Head>


### PR DESCRIPTION
## Changes
- Restrict CornyChat postMessage targetOrigin from `*` to `https://cornychat.com` — prevents any iframe from intercepting the nsec
- Remove debug console.logs that leak config paths from Home page and Layout component

## Review
Identified during code review — the postMessage `*` origin was the primary concern.