### PR TITLE
fix(ui): CSS transitions, Tailwind classes, copyright year

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -243,7 +243,7 @@ export default function Layout({ children, className }: LayoutProps) {
       <footer className="bg-black text-gray-400 py-8">
         <div className="container mx-auto px-6">
           <div className="flex flex-col md:flex-row items-center justify-between space-y-4 md:space-y-0">
-            <p>&copy; 2025 {config.site.organization.name} - All Rights Reserved.</p>
+            <p>&copy; {new Date().getFullYear()} {config.site.organization.name} - All Rights Reserved.</p>
             <div className="flex items-center gap-4">
               <a
                 href={config.site.externalLinks.meetup.url}

--- a/src/pages/committees.tsx
+++ b/src/pages/committees.tsx
@@ -262,7 +262,7 @@ export default function CommitteesPage() {
             <div className="text-gray-600">Active Committees</div>
           </div>
           <div className="bg-white border border-gray-200 rounded-lg p-6 text-center shadow-sm">
-            <div className="text-3xl font-bold green-600 mb-2">
+            <div className="text-3xl font-bold text-green-600 mb-2">
               {totalOpenings}
             </div>
             <div className="text-gray-600">Open Positions</div>

--- a/src/pages/shop.tsx
+++ b/src/pages/shop.tsx
@@ -1148,7 +1148,7 @@ export default function ShopPage() {
             <div className="text-lg text-gray-600 mb-6">
               Be the first to add a Bitcoin-accepting business to our directory!
             </div>
-            <div className="bg-gradient-to-r from-bitcoin-orange/10 to-orange-10 border border-bitcoin-orange/20 rounded-lg p-6 max-w-md mx-auto">
+            <div className="bg-gradient-to-r from-bitcoin-orange/10 to-orange-100 border border-bitcoin-orange/20 rounded-lg p-6 max-w-md mx-auto">
               <h3 className="text-lg font-bold text-gray-800 mb-3">
                 🚀 Add Your First Vendor
               </h3>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -68,8 +68,8 @@ h6 {
   background-color: var(--bitcoin-orange-hover);
 }
 
-/* Smooth transitions for better UX */
-* {
+/* Smooth transitions for interactive elements */
+a, button, input, textarea, select, summary, details {
   transition-property:
     color, background-color, border-color, text-decoration-color, fill, stroke;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);


### PR DESCRIPTION
## Changes
- Scope global CSS `*` transition to interactive elements only — the wildcard selector caused unnecessary repaints on every element
- Fix missing `text-` prefix: `green-600` → `text-green-600` in committees page
- Fix invalid Tailwind class: `bg-orange-10` → `bg-orange-100` in shop page
- Make footer copyright year dynamic with `new Date().getFullYear()`

Found during code review.