### PR TITLE
fix(perf): dedup nostr events, fix interval leak, remove redundant re-fetch

### DIFF
--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -262,12 +262,14 @@ export default function CalendarPage({
         setIsLoadingNostrEvents(false);
       }
 
-      // Add nostr events to existing events
+      // Add nostr events to existing events, deduplicating by ID
       setEvents((prevEvents) => {
+        const existingIds = new Set(prevEvents.map((e) => e.id));
+        const newEvents = nostrEvents.filter((e) => !existingIds.has(e.id));
         logger.debug(
-          `➕ Adding ${nostrEvents.length} nostr events to existing ${prevEvents.length} events`,
+          `➕ Adding ${newEvents.length} new nostr events to existing ${prevEvents.length} events (${nostrEvents.length - newEvents.length} duplicates skipped)`,
         );
-        const allEvents = sortEventsByTime([...prevEvents, ...nostrEvents]);
+        const allEvents = sortEventsByTime([...prevEvents, ...newEvents]);
         logger.debug(`📅 Total events after adding nostr: ${allEvents.length}`);
         return allEvents;
       });
@@ -362,54 +364,6 @@ export default function CalendarPage({
           eventId: result.eventId || "",
           naddr: result.naddr || "",
         });
-
-        // Fetch the event from relay to ensure it's rendered
-        setTimeout(async () => {
-          logger.debug(
-            "🔄 Fetching newly published event from relay to verify it was published...",
-          );
-          try {
-            logger.debug(
-              "📡 Calling fetchNostrCalendarEvents() to get latest events from relay...",
-            );
-            const nostrCalendarEvents = await fetchNostrCalendarEvents();
-            logger.debug(
-              `📨 Received ${nostrCalendarEvents.length} events from relay`,
-            );
-
-            logger.debug("🔄 Converting nostr events to calendar format...");
-            const nostrEvents = nostrCalendarEvents.map(
-              convertNostrEventToCalendar,
-            );
-            logger.debug(
-              `✅ Converted ${nostrEvents.length} nostr events to calendar format`,
-            );
-
-            logger.debug("🔄 Updating event list with newly fetched events...");
-            setEvents((prevEvents) => {
-              const allEvents = sortEventsByTime([
-                ...prevEvents,
-                ...nostrEvents,
-              ]);
-              logger.debug(
-                `📅 Updated total events: ${allEvents.length} (was ${prevEvents.length})`,
-              );
-              return allEvents;
-            });
-
-            logger.debug(
-              "✅ Successfully fetched and integrated newly published event from relay",
-            );
-          } catch (error) {
-            logger.error(
-              "💥 Failed to refetch events after publishing:",
-              error,
-            );
-            logger.warn(
-              "⚠️ Event was published successfully, but failed to refresh from relay",
-            );
-          }
-        }, 2000); // Wait 2 seconds for relay to propagate
       } else {
         const errorMsg = result.error || "Failed to publish to nostr";
         logger.error("❌ Event publishing failed:", errorMsg);

--- a/src/pages/donate.tsx
+++ b/src/pages/donate.tsx
@@ -16,7 +16,7 @@ import {
   neventEncode,
 } from "applesauce-core/helpers/pointers";
 import QRCode from "qrcode";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 export interface Zapraiser {
   goal: NostrEvent;
@@ -601,6 +601,10 @@ export default function DonatePage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Use ref to access current zapraisers in interval without recreating it
+  const zapraisersRef = useRef(zapraisers);
+  zapraisersRef.current = zapraisers;
+
   // Add a global animation style
   useEffect(() => {
     const style = document.createElement("style");
@@ -625,15 +629,14 @@ export default function DonatePage() {
 
   // Auto-refresh zap receipts every 30 seconds
   useEffect(() => {
-    if (zapraisers.length === 0) return; // Don't refresh if no zapraisers
-
     const interval = setInterval(async () => {
-      logger.debug("🔄 Auto-refreshing zap receipts...");
+      const current = zapraisersRef.current;
+      if (current.length === 0) return;
+      logger.debug("Auto-refreshing zap receipts...");
 
       // Update each zapraiser with new zap receipts
       const updatedzapraisers = await Promise.all(
-        zapraisers.map(async (zapraiser: Zapraiser) => {
-          // Fetch fresh zap receipts for this zap goal
+        current.map(async (zapraiser: Zapraiser) => {
           const receipts = await fetchZapReceipts(zapraiser.goal);
           const totalZapped = receipts.reduce(
             (sum, receipt) => sum + receipt.amount,
@@ -647,12 +650,11 @@ export default function DonatePage() {
         }),
       );
 
-      // Update state with new progress
       setzapraisers(updatedzapraisers);
-    }, 30000); // 30 seconds
+    }, 30000);
 
     return () => clearInterval(interval);
-  }, [zapraisers]); // Only run interval when zapraisers are loaded
+  }, []); // Empty deps — uses ref to access current state
 
   useEffect(() => {
     async function loadzapraisers() {


### PR DESCRIPTION
## Changes
- **Calendar dedup**: Filter out Nostr events whose ID already exists in state when merging — prevents duplicates from relay re-submissions
- **Calendar re-fetch removal**: Remove the 2-second `setTimeout` re-fetch after publishing an event. The event is already added optimistically to state; the re-fetch was adding duplicates
- **Donate interval leak**: Fix the auto-refresh interval by using `useRef` to access current `zapraisers` instead of putting it in the dependency array. The old code created a new 30s interval every time zapraisers updated, leaking intervals

Found during code review.