### PR TITLE
fix(ux): add modal a11y hook, fix admin check, improve alt text

### DIFF
--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+
+/**
+ * Hook for modal accessibility: handles Escape key to close and prevents
+ * background scroll while the modal is open.
+ *
+ * @param isOpen - whether the modal is currently visible
+ * @param onClose - callback to close the modal
+ */
+export function useModal(isOpen: boolean, onClose: () => void) {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+
+    // Prevent background scroll
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [isOpen, onClose]);
+}

--- a/src/pages/committees.tsx
+++ b/src/pages/committees.tsx
@@ -3,6 +3,7 @@ import Head from "next/head";
 import { config, basePath } from "@/config";
 import { isWhitelisted } from "@/config";
 import { useNostr } from "@/contexts/NostrContext";
+import { useModal } from "@/hooks/useModal";
 import {
   Committee,
   CommitteeMember,
@@ -96,9 +97,15 @@ export default function CommitteesPage() {
     throw new Error("No signing method available");
   };
 
-  // Show admin controls if user has a whitelisted pubkey OR if NIP-07 extension is present
-  // (extension users can sign events — the whitelist is checked server-side on publish)
-  const isAdmin = (user && isWhitelisted(user.pubkey)) || hasExtension;
+  // Show admin controls only if user has a whitelisted pubkey
+  // (this is a static site — there is no server-side whitelist enforcement)
+  const isAdmin = !!(user && isWhitelisted(user.pubkey));
+
+  // Modal accessibility: Escape key + scroll lock
+  const closeSelectedCommittee = useCallback(() => setSelectedCommittee(null), []);
+  const closeApplicationForm = useCallback(() => setShowApplicationForm(false), []);
+  useModal(!!selectedCommittee, closeSelectedCommittee);
+  useModal(showApplicationForm, closeApplicationForm);
 
   const loadAll = useCallback(async () => {
     setLoading(true);

--- a/src/pages/donate.tsx
+++ b/src/pages/donate.tsx
@@ -181,7 +181,7 @@ const NoteQRCode = ({
         <div className="p-2 bg-white border border-gray-200 rounded-lg">
           <img
             src={qrCodeUrl}
-            alt="QR Code for zapping"
+            alt={`QR code to zap: ${goal.content?.slice(0, 50) || 'fundraising goal'}`}
             className="w-32 h-32"
           />
         </div>
@@ -230,7 +230,7 @@ const NoteIdQRCode = ({
         <div className="p-2 bg-white border border-gray-200 rounded-lg">
           <img
             src={qrCodeUrl}
-            alt="QR Code for nostr URI"
+            alt={`QR code for note: ${goal.content?.slice(0, 50) || 'nostr event'}`}
             className="w-32 h-32"
           />
         </div>

--- a/src/pages/gallery.tsx
+++ b/src/pages/gallery.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import Head from "next/head";
 import { config, siteConfig, basePath } from "@/config";
 import { streamGalleryImages, GalleryImage, publishGalleryImage, uploadToBlossom } from "@/utils/galleryEvents";
 import { buildDeleteEvent, publishDelete } from "@/utils/pinboardEvents";
 import { useNostr } from "@/contexts/NostrContext";
 import EventActions from "@/components/EventActions";
+import { useModal } from "@/hooks/useModal";
 
 export default function GalleryPage() {
   const [images, setImages] = useState<GalleryImage[]>([]);
@@ -15,6 +16,12 @@ export default function GalleryPage() {
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const { user, hasExtension, loginWithExtension, signEvent } = useNostr();
+
+  // Modal accessibility: Escape key + scroll lock
+  const closeImageModal = useCallback(() => setSelectedImage(null), []);
+  const closeUploadModal = useCallback(() => setShowUploadModal(false), []);
+  useModal(!!selectedImage, closeImageModal);
+  useModal(showUploadModal, closeUploadModal);
 
   useEffect(() => {
     const stream = streamGalleryImages((image) => {


### PR DESCRIPTION
## Changes
- **New `useModal` hook** (`src/hooks/useModal.ts`): Handles Escape key to close modals and prevents background scroll while open
- **Committees page**: Apply `useModal` to both modals (details + application form)
- **Gallery page**: Apply `useModal` to both modals (image viewer + upload form)
- **Admin check fix**: Remove `|| hasExtension` from committees `isAdmin` — on a static site with no server-side enforcement, extension users shouldn't bypass the whitelist
- **QR code alt text**: Include the zapraiser goal content in alt text for screen readers

Found during code review.