### PR TITLE
fix(security): add sandbox attributes to all iframes

### DIFF
--- a/src/components/NewsletterForm.tsx
+++ b/src/components/NewsletterForm.tsx
@@ -6,6 +6,7 @@ const FORMSTR_URL =
 export default function NewsletterForm() {
   return (
     <iframe
+      sandbox="allow-scripts allow-same-origin allow-forms"
       src={FORMSTR_URL}
       height="700px"
       width="100%"

--- a/src/components/VideoSection.tsx
+++ b/src/components/VideoSection.tsx
@@ -27,6 +27,7 @@ export default function VideoSection({
         <div className="max-w-4xl mx-auto">
           <div className="relative w-full" style={{ paddingBottom: "56.25%" }}>
             <iframe
+              sandbox="allow-scripts allow-presentation"
               className="absolute top-0 left-0 w-full h-full rounded-lg shadow-lg"
               src={videoUrl}
               frameBorder="0"

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -961,6 +961,7 @@ export default function CalendarPage({
           {chatOpen && (
             <iframe
               ref={chatIframeRef}
+              sandbox="allow-scripts allow-same-origin"
               src={CORNYCHAT_URL}
               className="w-full border-0"
               style={{ height: "calc(100vh - 200px)", minHeight: "400px" }}

--- a/src/pages/education.tsx
+++ b/src/pages/education.tsx
@@ -643,6 +643,7 @@ function PinCard({ pin, onDelete, onEdit, onOpenArticle }: { pin: Pin; onDelete:
         <div className="w-full" style={{ aspectRatio: "16/9" }}>
           {ytId && (
             <iframe
+              sandbox="allow-scripts allow-presentation"
               src={`https://www.youtube.com/embed/${ytId}`}
               title={pin.title || "YouTube video"}
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
@@ -652,6 +653,7 @@ function PinCard({ pin, onDelete, onEdit, onOpenArticle }: { pin: Pin; onDelete:
           )}
           {vimeoId && (
             <iframe
+              sandbox="allow-scripts allow-presentation"
               src={`https://player.vimeo.com/video/${vimeoId}`}
               title={pin.title || "Vimeo video"}
               allow="autoplay; fullscreen; picture-in-picture"
@@ -661,6 +663,7 @@ function PinCard({ pin, onDelete, onEdit, onOpenArticle }: { pin: Pin; onDelete:
           )}
           {rumbleId && (
             <iframe
+              sandbox="allow-scripts allow-presentation"
               src={`https://rumble.com/embed/${rumbleId}/`}
               title={pin.title || "Rumble video"}
               allowFullScreen
@@ -674,6 +677,7 @@ function PinCard({ pin, onDelete, onEdit, onOpenArticle }: { pin: Pin; onDelete:
       {dt === "podcast" && isSpotifyShow && (
         <div className="w-full">
           <iframe
+            sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
             src={pin.externalRef!.replace("open.spotify.com/show/", "open.spotify.com/embed/show/") + "?utm_source=generator&theme=0"}
             title={pin.title || "Podcast"}
             width="100%"
@@ -690,6 +694,7 @@ function PinCard({ pin, onDelete, onEdit, onOpenArticle }: { pin: Pin; onDelete:
       {dt === "podcast-episode" && spotifyEpisodeId && (
         <div className="w-full">
           <iframe
+            sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
             src={`https://open.spotify.com/embed/episode/${spotifyEpisodeId}?utm_source=generator&theme=0`}
             title={pin.title || "Podcast Episode"}
             width="100%"


### PR DESCRIPTION
## Summary
P1 security fix: restrict third-party embedded content capabilities.

### Changes
Add `sandbox` attributes to all 8 iframes across 4 files:
- **YouTube/Vimeo/Rumble** (`education.tsx`): `allow-scripts allow-presentation`
- **Spotify show + episode** (`education.tsx`): `allow-scripts allow-popups allow-popups-to-escape-sandbox`
- **CornyChat** (`calendar.tsx`): `allow-scripts allow-same-origin` (required for getUserMedia)
- **Formstr** (`NewsletterForm.tsx`): `allow-scripts allow-same-origin allow-forms`
- **VideoSection** (`VideoSection.tsx`): `allow-scripts allow-presentation`

Without `sandbox`, a compromised embed source could access the parent page context, execute JS in the top-level origin, or navigate the parent page.

### Test Results
- `pnpm build` passes
- Playwright: 38 passed (failures are pre-existing)

## Files Changed
- `src/pages/education.tsx` — 5 iframes
- `src/pages/calendar.tsx` — 1 iframe
- `src/components/NewsletterForm.tsx` — 1 iframe
- `src/components/VideoSection.tsx` — 1 iframe