### PR TITLE
fix(security): markdown sanitization + guard test whitelist in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-dom": "^19.2.3",
     "react-leaflet": "^5.0.0",
     "react-markdown": "^10.1.0",
+    "rehype-sanitize": "^6.0.0",
     "rxjs": "^7.8.2",
     "window.nostrdb.js": "^0.5.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.7)(react@19.2.3)
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
@@ -1831,6 +1834,9 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -2738,6 +2744,9 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -5240,6 +5249,12 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      unist-util-position: 5.0.0
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -6285,6 +6300,11 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
 
   remark-parse@11.0.0:
     dependencies:

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -177,7 +177,7 @@ export function isWhitelisted(pubkey: string): boolean {
     hex = pubkey;
   }
   // In test mode, use the dynamically injected whitelist
-  if (typeof window !== "undefined" && (window as any).__TEST_WHITELIST) {
+  if (process.env.NODE_ENV !== "production" && typeof window !== "undefined" && (window as any).__TEST_WHITELIST) {
     return (window as any).__TEST_WHITELIST.includes(hex);
   }
   return WHITELISTED_PUBKEYS.includes(hex);

--- a/src/pages/committees.tsx
+++ b/src/pages/committees.tsx
@@ -19,6 +19,7 @@ import CommitteeMemberFormModal from "@/components/CommitteeMemberFormModal";
 import CommitteeOpeningFormModal from "@/components/CommitteeOpeningFormModal";
 import EventActions from "@/components/EventActions";
 import ReactMarkdown from "react-markdown";
+import rehypeSanitize from "rehype-sanitize";
 import { logger } from "@/utils/logger";
 
 // UI-facing committee shape (matches the existing rendering code)
@@ -653,7 +654,7 @@ export default function CommitteesPage() {
                             <div className="text-sm text-gray-600 mt-1">
                               {expandedOpenings.has(opening.id) ? (
                                 <div className="prose prose-sm max-w-none">
-                                  <ReactMarkdown>{opening.description}</ReactMarkdown>
+                                  <ReactMarkdown rehypePlugins={[rehypeSanitize]}>{opening.description}</ReactMarkdown>
                                   <button
                                     onClick={() => setExpandedOpenings((prev) => { const s = new Set(prev); s.delete(opening.id); return s; })}
                                     className="text-bitcoin-orange hover:underline text-xs font-medium mt-1"
@@ -666,7 +667,7 @@ export default function CommitteesPage() {
                                   onClick={() => setExpandedOpenings((prev) => new Set(prev).add(opening.id))}
                                   className="line-clamp-2 cursor-pointer"
                                 >
-                                  <ReactMarkdown>{opening.description}</ReactMarkdown>
+                                  <ReactMarkdown rehypePlugins={[rehypeSanitize]}>{opening.description}</ReactMarkdown>
                                   <span className="text-bitcoin-orange hover:underline text-xs font-medium">Show more</span>
                                 </div>
                               )}

--- a/src/pages/education.tsx
+++ b/src/pages/education.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import Head from "next/head";
 import ReactMarkdown from "react-markdown";
+import rehypeSanitize from "rehype-sanitize";
 import { config, siteConfig, basePath, nostrRelays } from "@/config";
 import { naddrEncode } from "@/utils/bech32";
 import { buildNewsletterEvent, publishNewsletter } from "@/utils/newsletterEvents";
@@ -265,7 +266,7 @@ export default function EducationPage() {
                 <h2 className="text-2xl font-bold text-gray-900 mb-4">{selectedArticle.title}</h2>
                 {selectedArticle.content && (
                   <div className="prose prose-sm max-w-none text-gray-700 mb-4">
-                    <ReactMarkdown>{selectedArticle.content}</ReactMarkdown>
+                    <ReactMarkdown rehypePlugins={[rehypeSanitize]}>{selectedArticle.content}</ReactMarkdown>
                   </div>
                 )}
                 <div className="pt-4 border-t border-gray-100 flex items-center gap-4">
@@ -1167,7 +1168,7 @@ function AddPinModal({
             )}
             {selectedType === "newsletter" && showPreview ? (
               <div className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm min-h-[200px] max-h-[400px] overflow-y-auto prose prose-sm prose-headings:text-gray-900 prose-h1:text-2xl prose-h1:font-bold prose-h1:border-b prose-h1:border-gray-200 prose-h1:pb-1 prose-h2:text-xl prose-h2:font-semibold prose-h3:text-lg prose-h3:font-semibold prose-p:text-gray-700 prose-code:bg-gray-100 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:font-mono prose-code:text-orange-700 prose-pre:bg-gray-900 prose-pre:text-gray-100">
-                <ReactMarkdown>{description}</ReactMarkdown>
+                <ReactMarkdown rehypePlugins={[rehypeSanitize]}>{description}</ReactMarkdown>
               </div>
             ) : (
               <textarea

--- a/src/utils/committeeEvents.ts
+++ b/src/utils/committeeEvents.ts
@@ -159,7 +159,7 @@ export { buildDeleteEvent, publishDelete };
 // (window.__TEST_WHITELIST) are included alongside the config pubkeys.
 function getAuthorPubkeys(): string[] {
   const base = WHITELISTED_PUBKEYS;
-  if (typeof window !== "undefined" && (window as any).__TEST_WHITELIST) {
+  if (process.env.NODE_ENV !== "production" && typeof window !== "undefined" && (window as any).__TEST_WHITELIST) {
     const extra = (window as any).__TEST_WHITELIST as string[];
     const merged = new Set([...base, ...extra]);
     return Array.from(merged);

--- a/src/utils/galleryEvents.ts
+++ b/src/utils/galleryEvents.ts
@@ -63,7 +63,7 @@ export async function uploadToBlossom(file: File, signer: SignerFn): Promise<str
  */
 export function streamGalleryImages(onImage: (image: GalleryImage) => void): { cancel: () => void } {
   // In test mode, use the dynamically injected whitelist
-  const testWhitelist = typeof window !== "undefined" && (window as any).__TEST_WHITELIST;
+  const testWhitelist = process.env.NODE_ENV !== "production" && typeof window !== "undefined" && (window as any).__TEST_WHITELIST;
   const authors = testWhitelist || WHITELISTED_PUBKEYS;
   const authorSet = new Set(authors);
   const seenIds = new Set<string>();
@@ -142,7 +142,7 @@ export async function publishGalleryImage(
   if (!caption.trim()) throw new Error("Caption is required.");
   if (!WHITELISTED_PUBKEYS.includes(pubkey)) {
     // In test mode, allow test-generated keys
-    const testWhitelist = typeof window !== "undefined" && (window as any).__TEST_WHITELIST;
+    const testWhitelist = process.env.NODE_ENV !== "production" && typeof window !== "undefined" && (window as any).__TEST_WHITELIST;
     if (!testWhitelist || !testWhitelist.includes(pubkey)) {
       return { success: false, error: "Not authorized to upload gallery images." };
     }

--- a/src/utils/pinboardEvents.ts
+++ b/src/utils/pinboardEvents.ts
@@ -3,7 +3,7 @@ import { nostrRelays, WHITELISTED_PUBKEYS, CLIENT_TAG, LOCATION_TAG } from "@/co
 
 // In test mode, use the dynamically injected whitelist
 function getWhitelistedAuthors(): string[] {
-  if (typeof window !== "undefined" && (window as any).__TEST_WHITELIST) {
+  if (process.env.NODE_ENV !== "production" && typeof window !== "undefined" && (window as any).__TEST_WHITELIST) {
     return (window as any).__TEST_WHITELIST;
   }
   return WHITELISTED_PUBKEYS;

--- a/src/utils/vendorAttestations.ts
+++ b/src/utils/vendorAttestations.ts
@@ -3,7 +3,7 @@ import { nostrRelays, WHITELISTED_PUBKEYS } from "@/config";
 
 // In test mode, use the dynamically injected whitelist
 function getWhitelistedAuthors(): string[] {
-  if (typeof window !== "undefined" && (window as any).__TEST_WHITELIST) {
+  if (process.env.NODE_ENV !== "production" && typeof window !== "undefined" && (window as any).__TEST_WHITELIST) {
     return (window as any).__TEST_WHITELIST;
   }
   return WHITELISTED_PUBKEYS;


### PR DESCRIPTION
## Summary
P1 security fixes: sanitize user-generated markdown content and prevent test backdoor in production.

### Changes

**Markdown Sanitization**
- Install `rehype-sanitize` and apply to all `ReactMarkdown` instances
- `education.tsx`: 2 instances (article content, newsletter preview)
- `committees.tsx`: 2 instances (opening descriptions)
- Prevents XSS from malicious HTML in Nostr-sourced markdown content

**Test Whitelist Guard**
- Guard all `__TEST_WHITELIST` checks with `process.env.NODE_ENV !== "production"`
- Files: `src/config/index.ts`, `src/utils/pinboardEvents.ts`, `src/utils/galleryEvents.ts`, `src/utils/committeeEvents.ts`, `src/utils/vendorAttestations.ts`
- In production builds, the test hook is compiled out (dead code elimination)
- Dev server and Playwright tests still use the hook normally

Without this guard, anyone could open browser devtools and set `window.__TEST_WHITELIST` to bypass the production whitelist.

### Test Results
- `pnpm build` passes
- `pnpm test` passes (28/28)
- Playwright @whitelist tests work in dev mode

## Files Changed
- `src/pages/education.tsx` — add rehype-sanitize
- `src/pages/committees.tsx` — add rehype-sanitize
- `src/config/index.ts` — guard __TEST_WHITELIST
- `src/utils/pinboardEvents.ts` — guard __TEST_WHITELIST
- `src/utils/galleryEvents.ts` — guard __TEST_WHITELIST (2 locations)
- `src/utils/committeeEvents.ts` — guard __TEST_WHITELIST
- `src/utils/vendorAttestations.ts` — guard __TEST_WHITELIST
- `package.json` / `pnpm-lock.yaml` — add rehype-sanitize