### PR TITLE
fix(security): CI/CD hardening + Content Security Policy

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -26,12 +26,17 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Install dependencies
-        run: npm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build and post-process
         run: |
-          npm run build
+          pnpm run build
           node scripts/post-build.js
         env:
           NEXT_SHARP_REQUIRE_CDN: 1

--- a/.github/workflows/staticS3.yml
+++ b/.github/workflows/staticS3.yml
@@ -32,12 +32,17 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Install dependencies
-        run: npm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build and export Next.js application
         run: |
-          npm run build
+          pnpm run build
           node scripts/post-build.js
           ls -lah out/
 
@@ -72,15 +77,16 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-2
 
-      - name: Run AWS CLI Command (Example)
+      - name: Deploy to S3 and invalidate CloudFront
         run: |
           ls -lah
           ls -lah out
-          did="E1MUWYLHGG5S4S"
           if [[ "${{ inputs.env }}" == "prod" ]]; then
             bucket=kcbitcoiners.com/
+            did="${{ secrets.CLOUDFRONT_DIST_ID_PROD }}"
           else
             bucket=dev.kcbitcoiners.com/
+            did="${{ secrets.CLOUDFRONT_DIST_ID_DEV }}"
           fi
           aws s3 sync out/ s3://${bucket} --delete
           aws cloudfront create-invalidation --distribution-id $did --paths "/*"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,6 +23,7 @@ const hasExistingServer = !!process.env.E2E_BASE_URL;
 
 export default defineConfig({
   testDir: "./tests",
+  testIgnore: /.*\.test\.ts$/,
   fullyParallel: true,
   forbidOnly: isCI,
   retries: isCI ? 2 : 0,

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -2,24 +2,10 @@ import { Html, Head, Main, NextScript } from "next/document";
 
 const bp = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
-// Content Security Policy applied via meta tag for static deployments
-// Note: GitHub Pages doesn't support HTTP headers, so meta tag is the only option.
-// CloudFront deployments should additionally use a response headers policy.
-const CSP = [
-  "default-src 'self'",
-  "script-src 'self' 'unsafe-inline'", // Next.js hydration requires unsafe-inline
-  "style-src 'self' 'unsafe-inline'",  // Tailwind CSS requires unsafe-inline
-  "frame-src https://www.youtube.com https://player.vimeo.com https://rumble.com https://open.spotify.com https://formstr.app https://cornychat.com",
-  "connect-src wss: https:",
-  "img-src 'self' data: https:",
-  "font-src 'self'",
-].join("; ");
-
 export default function Document() {
   return (
     <Html lang="en">
       <Head>
-        <meta httpEquiv="Content-Security-Policy" content={CSP} />
         <link rel="apple-touch-icon" href={`${bp}/apple-touch-icon.png`} />
         <link rel="manifest" href={`${bp}/manifest.json`} />
         <meta name="theme-color" content="#f7931a" />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -2,10 +2,24 @@ import { Html, Head, Main, NextScript } from "next/document";
 
 const bp = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
+// Content Security Policy applied via meta tag for static deployments
+// Note: GitHub Pages doesn't support HTTP headers, so meta tag is the only option.
+// CloudFront deployments should additionally use a response headers policy.
+const CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'", // Next.js hydration requires unsafe-inline
+  "style-src 'self' 'unsafe-inline'",  // Tailwind CSS requires unsafe-inline
+  "frame-src https://www.youtube.com https://player.vimeo.com https://rumble.com https://open.spotify.com https://formstr.app https://cornychat.com",
+  "connect-src wss: https:",
+  "img-src 'self' data: https:",
+  "font-src 'self'",
+].join("; ");
+
 export default function Document() {
   return (
     <Html lang="en">
       <Head>
+        <meta httpEquiv="Content-Security-Policy" content={CSP} />
         <link rel="apple-touch-icon" href={`${bp}/apple-touch-icon.png`} />
         <link rel="manifest" href={`${bp}/manifest.json`} />
         <meta name="theme-color" content="#f7931a" />


### PR DESCRIPTION
## Summary
P2 security fixes for CI/CD pipeline and static deployment security headers.

### Changes

**CI: Switch from npm to pnpm**
- `staticS3.yml`: Replace `npm install`/`npm run build` with pnpm, add `pnpm/action-setup@v4`
- `deploy-pages.yml`: Same pnpm migration
- Ensures CI uses `pnpm-lock.yaml` (the project's intended lockfile)

**CI: Move CloudFront Distribution ID to Secrets**
- Replace hardcoded `E1MUWYLHGG5S4S` with `${{ secrets.CLOUDFRONT_DIST_ID_PROD }}` and `${{ secrets.CLOUDFRONT_DIST_ID_DEV }}`
- **Action required**: Set these secrets in GitHub repo settings before merging

**Security Headers: CSP via meta tag**
- Add `Content-Security-Policy` meta tag in `_document.tsx`
- Policy allows: scripts (self + unsafe-inline for Next.js hydration), styles (self + unsafe-inline for Tailwind), frames (YouTube, Vimeo, Rumble, Spotify, Formstr, CornyChat), connections (wss: for Nostr relays, https: for APIs), images (self + data: + https: for Blossom CDN)
- GitHub Pages doesn't support HTTP headers, so meta tag is the only option

**Fix: Playwright config**
- Add `testIgnore` to exclude vitest `.test.ts` files from Playwright runner
- Fixes pre-existing issue where Playwright crashed loading vitest imports

### Test Results
- `pnpm build` passes
- `pnpm test` passes (28/28)
- Playwright: 38 passed

## Files Changed
- `.github/workflows/staticS3.yml` — pnpm + secrets
- `.github/workflows/deploy-pages.yml` — pnpm
- `src/pages/_document.tsx` — CSP meta tag
- `playwright.config.ts` — exclude vitest files

## Pre-merge Requirements
- [ ] Add `CLOUDFRONT_DIST_ID_PROD` secret in GitHub (value: the production CloudFront distribution ID)
- [ ] Add `CLOUDFRONT_DIST_ID_DEV` secret in GitHub (value: the dev CloudFront distribution ID)