### PR TITLE
fix(ci): look up CloudFront dist ID dynamically instead of hardcoding

### DIFF
--- a/.github/workflows/staticS3.yml
+++ b/.github/workflows/staticS3.yml
@@ -83,10 +83,19 @@ jobs:
           ls -lah out
           if [[ "${{ inputs.env }}" == "prod" ]]; then
             bucket=kcbitcoiners.com/
-            did="${{ secrets.CLOUDFRONT_DIST_ID_PROD }}"
+            domain=kcbitcoiners.com
           else
             bucket=dev.kcbitcoiners.com/
-            did="${{ secrets.CLOUDFRONT_DIST_ID_DEV }}"
+            domain=dev.kcbitcoiners.com
           fi
+          # Look up CloudFront distribution ID by domain alias
+          did=$(aws cloudfront list-distributions \
+            --query "DistributionList.Items[?Aliases.Items[?contains(@,'${domain}')]].Id" \
+            --output text)
+          if [[ -z "$did" ]]; then
+            echo "ERROR: No CloudFront distribution found for ${domain}"
+            exit 1
+          fi
+          echo "CloudFront distribution: ${did}"
           aws s3 sync out/ s3://${bucket} --delete
           aws cloudfront create-invalidation --distribution-id $did --paths "/*"


### PR DESCRIPTION
## Summary

Replaces the hardcoded CloudFront distribution ID with a dynamic AWS CLI lookup by domain alias.

## What changed
- **`.github/workflows/staticS3.yml`**: Instead of a hardcoded `did` value or GitHub secrets, the workflow now runs `aws cloudfront list-distributions` with a JMESPath query to find the distribution by its domain alias (kcbitcoiners.com / dev.kcbitcoiners.com)
- Fails with a clear error if no distribution is found

## Why
- The distribution ID is not a secret — it's publicly discoverable via the AWS API
- OIDC credentials are already configured in the workflow, so the lookup requires no additional secrets
- Eliminates drift between hardcoded/secrets values and the actual CloudFront distribution

## Testing
- `pnpm build` — passes (no app code changed)
- `pnpm test` — 28/28 pass
- CI will validate the AWS lookup on merge to master