### PR TITLE
fix(ci): use S3 origin lookup for CloudFront dist ID

### DIFF
--- a/.github/workflows/staticS3.yml
+++ b/.github/workflows/staticS3.yml
@@ -79,23 +79,22 @@ jobs:
 
       - name: Deploy to S3 and invalidate CloudFront
         run: |
-          ls -lah
           ls -lah out
           if [[ "${{ inputs.env }}" == "prod" ]]; then
-            bucket=kcbitcoiners.com/
-            domain=kcbitcoiners.com
+            bucket=kcbitcoiners.com
           else
-            bucket=dev.kcbitcoiners.com/
-            domain=dev.kcbitcoiners.com
+            bucket=dev.kcbitcoiners.com
           fi
-          # Look up CloudFront distribution ID by domain alias
+          # Look up CloudFront distribution by S3 origin bucket
           did=$(aws cloudfront list-distributions \
-            --query "DistributionList.Items[?Aliases.Items[?contains(@,'${domain}')]].Id" \
-            --output text)
-          if [[ -z "$did" ]]; then
-            echo "ERROR: No CloudFront distribution found for ${domain}"
+            --query "DistributionList.Items[?contains(Origins.Items[0].DomainName, '${bucket}.s3')].Id" \
+            --output text 2>/dev/null || echo "")
+          if [[ -z "$did" || "$did" == "None" ]]; then
+            echo "ERROR: No CloudFront distribution found for ${bucket}"
+            echo "Attempting fallback: list all distributions for debugging"
+            aws cloudfront list-distributions --query "DistributionList.Items[*].[Id,Aliases.Items,Origins.Items[0].DomainName,Comment]" --output table 2>/dev/null || true
             exit 1
           fi
           echo "CloudFront distribution: ${did}"
-          aws s3 sync out/ s3://${bucket} --delete
+          aws s3 sync out/ s3://${bucket}/ --delete
           aws cloudfront create-invalidation --distribution-id $did --paths "/*"


### PR DESCRIPTION
## Summary

Fixes the CloudFront distribution lookup from #99 which failed because the alias-based query didn't match.

## What changed
- Match distribution by **S3 origin bucket** (`kcbitcoiners.com.s3` / `dev.kcbitcoiners.com.s3`) instead of domain alias — more reliable since every distribution has an origin
- Handle JMESPath returning `"None"` string (not empty) when no match
- On failure, print all distributions for debugging before exiting

## Why the previous approach failed
The `Aliases.Items` query returned no match — the distributions may not have CNAME aliases configured. S3 origin is always present.

## Testing
- No app code changed — `pnpm build` and `pnpm test` unaffected
- CI will validate the lookup on merge