### PR TITLE
fix(deps): add missing @cashu/cashu-ts peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@cashu/cashu-ts": "^2.4.3",
     "@noble/curves": "^2.0.1",
     "@scure/base": "^2.0.0",
     "@types/qrcode": "^1.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   .:
     dependencies:
+      '@cashu/cashu-ts':
+        specifier: ^2.4.3
+        version: 2.9.0
       '@noble/curves':
         specifier: ^2.0.1
         version: 2.0.1
@@ -3425,7 +3428,6 @@ snapshots:
       '@noble/curves': 2.0.1
       '@noble/hashes': 2.0.1
       '@scure/bip32': 1.7.0
-    optional: true
 
   '@cashu/cashu-ts@3.2.2':
     dependencies:
@@ -3740,7 +3742,6 @@ snapshots:
   '@noble/curves@1.9.7':
     dependencies:
       '@noble/hashes': 1.8.0
-    optional: true
 
   '@noble/curves@2.0.1':
     dependencies:
@@ -3854,7 +3855,6 @@ snapshots:
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
-    optional: true
 
   '@scure/bip32@2.0.1':
     dependencies:


### PR DESCRIPTION
## Problem
CI build on master is broken: `Module not found: Can't resolve '@cashu/cashu-ts'`

This was introduced by the merge of PR #96 (blossom-client-sdk v5). The v5 SDK lists `@cashu/cashu-ts@^2.4.3` as a peer dependency but it was never added to `package.json`.

## Fix
Add `@cashu/cashu-ts@^2.4.3` as a direct dependency. Installs v2.9.0 which satisfies the peer requirement.

## Testing
- `pnpm build` passes
- Deploy CI will validate on merge