### PR TITLE
debug(gallery): production-visible upload debug logging

### DIFF
--- a/src/pages/gallery.tsx
+++ b/src/pages/gallery.tsx
@@ -76,10 +76,15 @@ export default function GalleryPage() {
     try {
       if (!uploadForm.file || !uploadForm.caption) throw new Error("Please fill in all fields");
       if (!user) throw new Error("You must be logged in to upload");
+      window.alert(`[DEBUG] Starting upload to blossom...\nServer: ${"blossomConfig" in globalThis ? "unknown" : "check config"}\nPubkey: ${user.pubkey}\nFile: ${uploadForm.file.name} (${(uploadForm.file.size / 1024).toFixed(1)} KB)\n\nClick OK to proceed.`);
+      setUploadError("Step 1/3: Uploading to blossom...");
       const descriptor = await uploadToBlossom(uploadForm.file, signEvent);
+      setUploadError("Step 2/3: Building BUD-10 URI...");
       const blossomUri = buildGalleryBlossomURI(descriptor, uploadForm.file, user.pubkey);
+      setUploadError("Step 3/3: Publishing to Nostr relays...");
       const result = await publishGalleryImage(descriptor, uploadForm.caption, signEvent, user.pubkey, blossomUri);
       if (!result.success) throw new Error(result.error || "Failed to upload");
+      setUploadError(null);
       const newImage: GalleryImage = {
         id: result.eventId || `local-${Date.now()}`,
         kind: 20,

--- a/src/utils/galleryEvents.ts
+++ b/src/utils/galleryEvents.ts
@@ -57,6 +57,7 @@ function extFromFile(file: File): string {
  */
 export async function uploadToBlossom(file: File, signer: SignerFn): Promise<BlobDescriptor> {
   const server = blossomConfig?.server || "https://blossom.primal.net";
+  window.alert(`[blossom:1] Server: ${server}\nConfig: ${JSON.stringify(blossomConfig)}\nFile: ${file.name} (${file.size} bytes, ${file.type})`);
 
   // Compute SHA-256 of the file
   const fileBuffer = await file.arrayBuffer();
@@ -78,10 +79,16 @@ export async function uploadToBlossom(file: File, signer: SignerFn): Promise<Blo
     ],
     content: `Upload ${file.name}`,
   };
+  window.alert(`[blossom:2] Asking signer for auth event...\nAuth draft kind: ${authEvent.kind}\nTags: ${JSON.stringify(authEvent.tags)}`);
+
   const signedAuth = await signer(authEvent);
+  window.alert(`[blossom:3] Got signed auth!\npubkey: ${signedAuth.pubkey}\nid: ${signedAuth.id}\nsig: ${(signedAuth.sig as string)?.slice(0, 20)}...`);
+
   const authBase64 = btoa(JSON.stringify(signedAuth));
 
   const uploadUrl = `${server}/upload?sha256=${sha256}`;
+  window.alert(`[blossom:4] Sending PUT to: ${uploadUrl}`);
+
   const response = await fetch(uploadUrl, {
     method: "PUT",
     headers: {
@@ -91,12 +98,15 @@ export async function uploadToBlossom(file: File, signer: SignerFn): Promise<Blo
     body: file,
   });
 
+  window.alert(`[blossom:5] Response: ${response.status} ${response.statusText}`);
+
   if (!response.ok) {
     const text = await response.text().catch(() => "");
+    window.alert(`[blossom:ERROR] ${response.status}: ${text}`);
     throw new Error(`Upload failed (${response.status}): ${text}`);
   }
   const result = await response.json();
-  // Blossom returns { url, sha256, size, type, uploaded }
+  window.alert(`[blossom:6] Success! URL: ${result.url}`);
   if (!result.sha256) {
     throw new Error("Unexpected upload response");
   }


### PR DESCRIPTION
## Purpose
Temporary debug PR — merge, test on production, then revert.

console.log is stripped by Next.js production builds, so previous debug logging was invisible. Using window.alert at each step to see exactly where the upload flow hangs or fails.

## Alerts you'll see on upload
1. `[blossom:1]` — server URL and config
2. `[blossom:2]` — auth event draft (tags, kind)
3. `[blossom:3]` — signed auth result (pubkey, id, sig) — **if this doesn't appear, the signer/extension is hanging**
4. `[blossom:4]` — PUT URL being called
5. `[blossom:5]` — HTTP response status
6. `[blossom:6]` — success with URL
7. `[blossom:ERROR]` — error body from server