### PR TITLE
fix(gallery): switch to nostr.build upload with NIP-98 auth

### DIFF
--- a/src/pages/gallery.tsx
+++ b/src/pages/gallery.tsx
@@ -7,7 +7,6 @@ import {
   GalleryImage,
   publishGalleryImage,
   uploadToBlossom,
-  buildGalleryBlossomURI,
   getBlossomServers,
 } from "@/utils/galleryEvents";
 import { buildDeleteEvent, publishDelete } from "@/utils/pinboardEvents";
@@ -76,23 +75,18 @@ export default function GalleryPage() {
     try {
       if (!uploadForm.file || !uploadForm.caption) throw new Error("Please fill in all fields");
       if (!user) throw new Error("You must be logged in to upload");
-      const descriptor = await uploadToBlossom(uploadForm.file, signEvent);
-      const blossomUri = buildGalleryBlossomURI(descriptor, uploadForm.file, user.pubkey);
-      const result = await publishGalleryImage(descriptor, uploadForm.caption, signEvent, user.pubkey, blossomUri);
+      const imageUrl = await uploadToBlossom(uploadForm.file, signEvent);
+      const result = await publishGalleryImage(imageUrl, uploadForm.caption, signEvent, user.pubkey);
       if (!result.success) throw new Error(result.error || "Failed to upload");
       const newImage: GalleryImage = {
         id: result.eventId || `local-${Date.now()}`,
         kind: 20,
         pubkey: user.pubkey,
-        tags: [["imeta", `url ${descriptor.url} m ${descriptor.type || "image/jpeg"} alt ${uploadForm.caption}`]],
+        tags: [["imeta", `url ${imageUrl} m image/jpeg alt ${uploadForm.caption}`]],
         content: uploadForm.caption,
-        imageUrl: descriptor.url,
+        imageUrl,
         caption: uploadForm.caption,
         created_at: Math.floor(Date.now() / 1000),
-        sha256: descriptor.sha256,
-        mimeType: descriptor.type,
-        size: descriptor.size,
-        blossomUri,
       };
       setImages((prev) => (prev.some((i) => i.id === newImage.id) ? prev : [newImage, ...prev]));
       setShowUploadModal(false);

--- a/src/utils/galleryEvents.ts
+++ b/src/utils/galleryEvents.ts
@@ -1,10 +1,8 @@
-import { buildBlossomURI, getServersFromServerListEvent, USER_BLOSSOM_SERVER_LIST_KIND } from "blossom-client-sdk";
-import type { BlobDescriptor } from "blossom-client-sdk";
+import { getServersFromServerListEvent, USER_BLOSSOM_SERVER_LIST_KIND } from "blossom-client-sdk";
 import { pool } from "@/lib/nostr";
 import {
   WHITELISTED_PUBKEYS,
   nostrRelays,
-  blossomConfig,
   CLIENT_TAG,
   LOCATION_TAG,
 } from "@/config";
@@ -32,92 +30,51 @@ export interface GalleryImage {
   blossomUri?: string;
 }
 
-const MIME_EXT: Record<string, string> = {
-  "image/jpeg": "jpg",
-  "image/jpg": "jpg",
-  "image/png": "png",
-  "image/gif": "gif",
-  "image/webp": "webp",
-  "image/avif": "avif",
-  "image/svg+xml": "svg",
-};
-
-function extFromFile(file: File): string {
-  const fromMime = MIME_EXT[file.type];
-  if (fromMime) return fromMime;
-  const dot = file.name.lastIndexOf(".");
-  if (dot > -1) return file.name.slice(dot + 1).toLowerCase();
-  return "bin";
-}
-
 /**
- * Upload a file to the configured Blossom server.
- * Uses manual HTTP + BUD-06 auth with `u` and `method` tags because
- * blossom.f7z.io doesn't accept the SDK v5's `server`-tag auth format.
+ * Upload an image file to nostr.build using NIP-98 (kind 27235) auth.
+ * Matches the approach used by ray_repub which is known to work.
  */
-export async function uploadToBlossom(file: File, signer: SignerFn): Promise<BlobDescriptor> {
-  const server = blossomConfig?.server || "https://blossom.primal.net";
+export async function uploadToBlossom(file: File, signer: SignerFn): Promise<string> {
+  const uploadUrl = "https://nostr.build/api/v2/upload/files";
 
-  // Compute SHA-256 of the file
-  const fileBuffer = await file.arrayBuffer();
-  const hashBuffer = await crypto.subtle.digest("SHA-256", fileBuffer);
-  const sha256 = Array.from(new Uint8Array(hashBuffer))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-
-  // Build BUD-06 auth event with `u` and `method` tags (required by blossom.f7z.io)
+  // Create NIP-98 auth event (kind 27235)
   const authEvent = {
-    kind: 24242,
+    kind: 27235,
     created_at: Math.floor(Date.now() / 1000),
     tags: [
-      ["u", server],
-      ["method", "PUT"],
-      ["x", sha256],
-      ["t", "upload"],
-      ["expiration", String(Math.floor(Date.now() / 1000) + 300)],
+      ["u", uploadUrl],
+      ["method", "POST"],
     ],
     content: `Upload ${file.name}`,
   };
   const signedAuth = await signer(authEvent);
-  // URL-safe base64 — blossom servers expect this encoding per BUD-06
-  const authBase64 = btoa(JSON.stringify(signedAuth))
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/g, "");
+  const authBase64 = btoa(JSON.stringify(signedAuth));
 
-  const uploadUrl = `${server}/upload?sha256=${sha256}`;
+  // Upload via POST with FormData
+  const formData = new FormData();
+  formData.append("file", file);
+
   const response = await fetch(uploadUrl, {
-    method: "PUT",
+    method: "POST",
     headers: {
       Authorization: `Nostr ${authBase64}`,
-      "Content-Type": file.type || "application/octet-stream",
     },
-    body: file,
+    body: formData,
   });
 
   if (!response.ok) {
     const text = await response.text().catch(() => "");
     throw new Error(`Upload failed (${response.status}): ${text}`);
   }
-  const result = await response.json();
-  // Blossom returns { url, sha256, size, type, uploaded }
-  if (!result.sha256) {
-    throw new Error("Unexpected upload response");
-  }
-  return result as BlobDescriptor;
-}
 
-/** Build a BUD-10 blossom: URI from an upload result and author. */
-export function buildGalleryBlossomURI(descriptor: BlobDescriptor, file: File, pubkey: string): string {
-  const primary = blossomConfig?.server;
-  const servers = primary ? [new URL(primary).host] : [];
-  return buildBlossomURI({
-    sha256: descriptor.sha256,
-    ext: extFromFile(file),
-    servers,
-    authors: [pubkey],
-    size: descriptor.size,
-  });
+  const result = await response.json();
+
+  // nostr.build returns { status: "success", data: [{ url: "..." }] }
+  if (result.status === "success" && result.data?.[0]?.url) {
+    return result.data[0].url as string;
+  }
+
+  throw new Error(`Unexpected upload response: ${JSON.stringify(result)}`);
 }
 
 function parseImetaFields(imetaTag: string[]): Record<string, string[]> {
@@ -280,16 +237,14 @@ export function streamGalleryImages(onImage: (image: GalleryImage) => void): {
 }
 
 export async function publishGalleryImage(
-  descriptor: BlobDescriptor,
+  imageUrl: string,
   caption: string,
   signer: SignerFn,
   pubkey: string,
-  blossomUri?: string,
 ): Promise<{ success: boolean; eventId?: string; error?: string }> {
-  if (!descriptor.url || !descriptor.url.startsWith("http")) throw new Error("Invalid image URL.");
+  if (!imageUrl || !imageUrl.startsWith("http")) throw new Error("Invalid image URL.");
   if (!caption.trim()) throw new Error("Caption is required.");
   if (!WHITELISTED_PUBKEYS.includes(pubkey)) {
-    // In test mode, allow test-generated keys
     const testWhitelist =
       process.env.NODE_ENV !== "production" &&
       typeof window !== "undefined" &&
@@ -302,28 +257,14 @@ export async function publishGalleryImage(
     }
   }
 
-  const mime = descriptor.type || "image/jpeg";
-
-  // NIP-92 imeta entries are space-separated "key value" pairs spread across tag values
-  const imetaParts = [
-    `url ${descriptor.url}`,
-    `m ${mime}`,
-    `x ${descriptor.sha256}`,
-    `size ${descriptor.size}`,
-    `alt ${caption}`,
-  ];
-  if (blossomUri) imetaParts.push(`blossom ${blossomUri}`);
+  const imetaContent = `url ${imageUrl} m image/jpeg alt ${caption}`;
 
   // 1. Publish kind 20 image event
   const tags: string[][] = [
     [...CLIENT_TAG],
     [...LOCATION_TAG],
-    ["imeta", ...imetaParts],
-    ["x", descriptor.sha256],
-    ["m", mime],
-    ["size", String(descriptor.size)],
+    ["imeta", imetaContent],
   ];
-  if (blossomUri) tags.push(["blossom", blossomUri]);
 
   const imageEvent = {
     kind: 20,

--- a/tests/gallery-upload-debug.spec.ts
+++ b/tests/gallery-upload-debug.spec.ts
@@ -1,7 +1,6 @@
 /**
  * Gallery upload debug tests.
- * These tests intercept the blossom HTTP call to verify the auth event
- * structure, encoding, and server response.
+ * Intercepts nostr.build upload to verify NIP-98 auth and end-to-end flow.
  */
 import { test, expect } from "@playwright/test";
 import { injectNostrExtension, getTestKeys } from "./helpers";
@@ -15,123 +14,31 @@ test.describe("@gallery @whitelist upload debug", () => {
     await page.waitForTimeout(2000);
   });
 
-  test("upload sends URL-safe base64 in Authorization header", async ({
+  test("upload sends NIP-98 auth with correct event structure", async ({
     page,
   }) => {
     const keys = getTestKeys();
 
-    // Intercept the blossom upload to inspect the auth header
     let capturedAuth: string | null = null;
     let capturedUrl: string | null = null;
     let capturedMethod: string | null = null;
-    let capturedHeaders: Record<string, string> | null = null;
 
-    await page.route("**/blossom.*/**", async (route) => {
+    await page.route("**/nostr.build/**", async (route) => {
       const request = route.request();
-      const method = request.method();
-
-      if (method === "PUT" && !capturedUrl) {
+      if (request.method() === "POST" && !capturedUrl) {
         capturedUrl = request.url();
-        capturedMethod = method;
-        capturedHeaders = request.headers();
-        const authHeader = capturedHeaders["authorization"];
+        capturedMethod = request.method();
+        const authHeader = request.headers()["authorization"];
         if (authHeader?.startsWith("Nostr ")) {
           capturedAuth = authHeader.slice(6);
         }
       }
-
-      // Mock success for all blossom requests
       await route.fulfill({
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
-          url: "https://blossom.f7z.io/mock-test-image.png",
-          sha256: "a".repeat(64),
-          size: 100,
-          type: "image/png",
-          uploaded: Date.now() / 1000,
-        }),
-      });
-    });
-
-    // Open upload modal and fill form
-    await page.getByTestId("add-photo-btn").click();
-    await expect(page.getByTestId("upload-modal")).toBeVisible();
-
-    // Should be logged in via localStorage pre-population
-    const loginBtn = page.getByRole("button", {
-      name: /login with nostr extension/i,
-    });
-    const loginVisible = await loginBtn.isVisible().catch(() => false);
-    if (loginVisible) {
-      await loginBtn.click();
-      await page.waitForTimeout(1000);
-    }
-
-    // Create test image
-    const fixturesDir = path.join(__dirname, "fixtures");
-    if (!fs.existsSync(fixturesDir))
-      fs.mkdirSync(fixturesDir, { recursive: true });
-    const testImagePath = path.join(fixturesDir, "test-image.png");
-    if (!fs.existsSync(testImagePath)) {
-      const png = Buffer.from(
-        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
-        "base64",
-      );
-      fs.writeFileSync(testImagePath, png);
-    }
-
-    await page.getByTestId("upload-file-input").setInputFiles(testImagePath);
-    await page.getByTestId("upload-caption").fill("Debug test upload");
-
-    // Submit
-    await page.getByTestId("upload-submit").click();
-
-    // Wait for the request to be intercepted
-    await page.waitForTimeout(3000);
-
-    // Verify the request was captured
-    expect(capturedUrl).toBeTruthy();
-    expect(capturedMethod).toBe("PUT");
-    expect(capturedAuth).toBeTruthy();
-
-    // Verify URL-safe base64 encoding — no + / or = characters
-    expect(capturedAuth).not.toMatch(/\+/);
-    expect(capturedAuth).not.toMatch(/\//);
-    expect(capturedAuth).not.toMatch(/=/);
-
-    // Verify the auth event can be decoded back
-    const decoded = JSON.parse(
-      Buffer.from(capturedAuth!, "base64").toString("utf-8"),
-    );
-    expect(decoded.kind).toBe(24242);
-    expect(decoded.pubkey).toBe(keys.pubkeyHex);
-    expect(decoded.id).toBeTruthy();
-    expect(decoded.sig).toBeTruthy();
-
-    // Verify auth event has the required tags
-    const tagNames = decoded.tags.map((t: string[]) => t[0]);
-    expect(tagNames).toContain("u");
-    expect(tagNames).toContain("method");
-    expect(tagNames).toContain("x");
-    expect(tagNames).toContain("t");
-    expect(tagNames).toContain("expiration");
-  });
-
-  test("upload form works end-to-end with mocked blossom", async ({
-    page,
-  }) => {
-    // Mock blossom + relay
-    await page.route("**/blossom.*/**", async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          url: "https://blossom.f7z.io/mock-test-image.png",
-          sha256: "a".repeat(64),
-          size: 100,
-          type: "image/png",
-          uploaded: Date.now() / 1000,
+          status: "success",
+          data: [{ url: "https://nostr.build/mock-test-image.png" }],
         }),
       });
     });
@@ -148,40 +55,96 @@ test.describe("@gallery @whitelist upload debug", () => {
       }
     });
 
-    // Open upload modal
     await page.getByTestId("add-photo-btn").click();
     await expect(page.getByTestId("upload-modal")).toBeVisible();
 
-    const loginBtn = page.getByRole("button", {
-      name: /login with nostr extension/i,
-    });
+    const loginBtn = page.getByRole("button", { name: /login with nostr extension/i });
     const loginVisible = await loginBtn.isVisible().catch(() => false);
     if (loginVisible) {
       await loginBtn.click();
       await page.waitForTimeout(1000);
     }
 
-    // Create test image
     const fixturesDir = path.join(__dirname, "fixtures");
-    if (!fs.existsSync(fixturesDir))
-      fs.mkdirSync(fixturesDir, { recursive: true });
+    if (!fs.existsSync(fixturesDir)) fs.mkdirSync(fixturesDir, { recursive: true });
     const testImagePath = path.join(fixturesDir, "test-image.png");
     if (!fs.existsSync(testImagePath)) {
-      const png = Buffer.from(
+      fs.writeFileSync(testImagePath, Buffer.from(
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
         "base64",
-      );
-      fs.writeFileSync(testImagePath, png);
+      ));
+    }
+
+    await page.getByTestId("upload-file-input").setInputFiles(testImagePath);
+    await page.getByTestId("upload-caption").fill("Debug test upload");
+    await page.getByTestId("upload-submit").click();
+    await page.waitForTimeout(3000);
+
+    expect(capturedUrl).toContain("nostr.build");
+    expect(capturedMethod).toBe("POST");
+    expect(capturedAuth).toBeTruthy();
+
+    const decoded = JSON.parse(Buffer.from(capturedAuth!, "base64").toString("utf-8"));
+    expect(decoded.kind).toBe(27235);
+    expect(decoded.pubkey).toBe(keys.pubkeyHex);
+    expect(decoded.id).toBeTruthy();
+    expect(decoded.sig).toBeTruthy();
+
+    const tagNames = decoded.tags.map((t: string[]) => t[0]);
+    expect(tagNames).toContain("u");
+    expect(tagNames).toContain("method");
+  });
+
+  test("upload form works end-to-end with mocked nostr.build", async ({
+    page,
+  }) => {
+    await page.route("**/nostr.build/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "success",
+          data: [{ url: "https://nostr.build/mock-test-image.png" }],
+        }),
+      });
+    });
+
+    await page.route("**/relay.*/**", async (route) => {
+      if (route.request().method() === "POST") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ ok: true, id: "mock" }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.getByTestId("add-photo-btn").click();
+    await expect(page.getByTestId("upload-modal")).toBeVisible();
+
+    const loginBtn = page.getByRole("button", { name: /login with nostr extension/i });
+    const loginVisible = await loginBtn.isVisible().catch(() => false);
+    if (loginVisible) {
+      await loginBtn.click();
+      await page.waitForTimeout(1000);
+    }
+
+    const fixturesDir = path.join(__dirname, "fixtures");
+    if (!fs.existsSync(fixturesDir)) fs.mkdirSync(fixturesDir, { recursive: true });
+    const testImagePath = path.join(fixturesDir, "test-image.png");
+    if (!fs.existsSync(testImagePath)) {
+      fs.writeFileSync(testImagePath, Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
+        "base64",
+      ));
     }
 
     await page.getByTestId("upload-file-input").setInputFiles(testImagePath);
     await page.getByTestId("upload-caption").fill("E2E test upload");
-
     await page.getByTestId("upload-submit").click();
 
-    // Modal should close on success
-    await expect(page.getByTestId("upload-modal")).not.toBeVisible({
-      timeout: 10000,
-    });
+    await expect(page.getByTestId("upload-modal")).not.toBeVisible({ timeout: 10000 });
   });
 });


### PR DESCRIPTION
## Problem
Gallery upload on kcbitcoiners.com hangs/fails. Blossom.f7z.io returns 401 despite correct BUD-06 auth events.

## Solution
Switch to nostr.build upload API with NIP-98 (kind 27235) auth — same approach used by ray_repub which is known to work.

### Changes
- **`uploadToBlossom`**: POST FormData to `nostr.build/api/v2/upload/files` with NIP-98 auth instead of PUT to blossom.f7z.io with BUD-06
- **`publishGalleryImage`**: Simplified to take URL string instead of BlobDescriptor
- Removed `buildGalleryBlossomURI` and unused blossom imports
- Updated debug tests to match new endpoint

### Testing
All 13 gallery tests pass (11 existing + 2 debug tests).