### PR TITLE
NIP-18 repost, NIP-57 zap improvements, sort by zaps

### DIFF
--- a/src/components/EventActions.tsx
+++ b/src/components/EventActions.tsx
@@ -1,5 +1,9 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import ZapModal from "./ZapModal";
+import { pool } from "@/lib/nostr";
+import { nostrRelays, CLIENT_TAG, LOCATION_TAG } from "@/config";
+import { fetchZapTotal } from "@/utils/zaps";
+import { neventEncode } from "@/utils/bech32";
 
 export interface EventAction {
   label: string;
@@ -24,7 +28,7 @@ interface EventActionsProps {
   onDelete?: () => void;
   /** Callback when user requests edit. If not provided, edit option is hidden. */
   onEdit?: () => void;
-  /** Signer function for zap support. If not provided, zap option is hidden. */
+  /** Signer function for zap/repost support. If not provided, those options are hidden. */
   signEvent?: SignerFn;
   /** Current user's pubkey for zap support. */
   pubkey?: string | null;
@@ -43,12 +47,30 @@ export default function EventActions({
   const [showRaw, setShowRaw] = useState(false);
   const [showZap, setShowZap] = useState(false);
   const [copied, setCopied] = useState<string | null>(null);
+  const [repostStatus, setRepostStatus] = useState<"idle" | "loading" | "done">("idle");
+  const [repostResult, setRepostResult] = useState<{
+    nevent: string;
+    relays: string[];
+  } | null>(null);
+  const [zapTotal, setZapTotal] = useState<number | null>(null);
+  const [zapRefreshKey, setZapRefreshKey] = useState(0);
   const [position, setPosition] = useState<{
     top: number;
     right: number;
   } | null>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  // Fetch zap total for this event — re-fetches when zapRefreshKey changes
+  useEffect(() => {
+    const id = event.id as string | undefined;
+    if (!id) return;
+    let cancelled = false;
+    fetchZapTotal(id).then((total) => {
+      if (!cancelled && total > 0) setZapTotal(total);
+    });
+    return () => { cancelled = true; };
+  }, [event.id, zapRefreshKey]);
 
   const updatePosition = useCallback(() => {
     if (triggerRef.current) {
@@ -111,14 +133,61 @@ export default function EventActions({
     setOpen(false);
   };
 
+  // NIP-18 repost handler — publishes a kind 16 (generic repost) event
+  const handleRepost = async () => {
+    if (!signEvent || !eventId || !event.pubkey) return;
+    setRepostStatus("loading");
+
+    try {
+      const relayHint = nostrRelays[0] || "wss://relay.damus.io";
+      const tags: string[][] = [
+        ["e", eventId, relayHint],
+        ["p", event.pubkey as string],
+      ];
+      if (eventKind) tags.push(["k", String(eventKind)]);
+      tags.push([...CLIENT_TAG], [...LOCATION_TAG]);
+
+      const unsigned = {
+        kind: 16,
+        content: "",
+        tags,
+        created_at: Math.floor(Date.now() / 1000),
+      };
+
+      const signed = await signEvent(unsigned);
+      await pool.publish(nostrRelays, signed as any);
+
+      // Build nevent link for the reposted event
+      const nevent = neventEncode({
+        id: eventId,
+        relays: [relayHint],
+        author: event.pubkey as string,
+        kind: eventKind,
+      });
+
+      setRepostStatus("done");
+      setRepostResult({ nevent, relays: nostrRelays });
+      setOpen(false);
+    } catch {
+      setRepostStatus("idle");
+      setOpen(false);
+    }
+  };
+
   const toggleMenu = () => {
     updatePosition();
     setOpen(!open);
   };
 
+  // Close repost popup
+  const closeRepostResult = () => {
+    setRepostResult(null);
+    setRepostStatus("idle");
+  };
+
   const actions: EventAction[] = [
-    // Zap action — only when signer is provided
-    ...(signEvent && event.pubkey
+    // Zap action — show whenever the event has an author pubkey
+    ...(event.pubkey
       ? [
           {
             label: "Zap",
@@ -130,9 +199,19 @@ export default function EventActions({
           },
         ]
       : []),
+    // NIP-18 repost — only when signer and event id exist
+    ...(signEvent && eventId
+      ? [
+          {
+            label: repostStatus === "done" ? "Reposted!" : "Repost",
+            icon: "\u21BB",
+            onClick: handleRepost,
+          },
+        ]
+      : []),
     {
       label: copied === "Share link" ? "Copied!" : "Share",
-      icon: "🔗",
+      icon: "\u{1F517}",
       onClick: handleShare,
     },
     {
@@ -144,21 +223,22 @@ export default function EventActions({
       ? [
           {
             label: copied === "Event ID" ? "Copied!" : "Copy Event ID",
-            icon: "📋",
+            icon: "\u{1F4CB}",
             onClick: handleCopyId,
           },
         ]
       : []),
     {
       label: copied === "Raw JSON" ? "Copied!" : "Copy Raw JSON",
-      icon: "📄",
+      icon: "\u{1F4C4}",
       onClick: handleCopyRaw,
     },
-    ...(onEdit
+    // Only show edit/delete when the current user owns this event
+    ...(onEdit && pubkey && event.pubkey === pubkey
       ? [
           {
             label: "Edit",
-            icon: "✏️",
+            icon: "\u270F\uFE0F",
             onClick: () => {
               onEdit();
               setOpen(false);
@@ -166,11 +246,11 @@ export default function EventActions({
           },
         ]
       : []),
-    ...(onDelete
+    ...(onDelete && pubkey && event.pubkey === pubkey
       ? [
           {
             label: "Delete",
-            icon: "🗑️",
+            icon: "\u{1F5D1}\uFE0F",
             onClick: () => {
               onDelete();
               setOpen(false);
@@ -192,6 +272,14 @@ export default function EventActions({
       >
         ...
       </button>
+
+      {/* Zap total badge */}
+      {zapTotal !== null && (
+        <div className={`text-xs text-bitcoin-orange font-semibold flex items-center gap-0.5 justify-center ${className || ""}`}>
+          <span>&#x26A1;</span>
+          <span>{zapTotal >= 1000000 ? `${(zapTotal / 1000000).toFixed(1)}M` : zapTotal >= 1000 ? `${(zapTotal / 1000).toFixed(1)}k` : zapTotal}</span>
+        </div>
+      )}
 
       {/* Dropdown — fixed positioning to escape overflow clipping */}
       {open && position && (
@@ -237,14 +325,70 @@ export default function EventActions({
         </div>
       )}
 
+      {/* Repost success popup — shows relays and nevent link */}
+      {repostResult && (
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50"
+          onClick={closeRepostResult}
+        >
+          <div
+            className="bg-white rounded-lg shadow-2xl max-w-md w-full p-6"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex justify-between items-center mb-4">
+              <h3 className="text-lg font-bold text-gray-900">Reposted!</h3>
+              <button
+                onClick={closeRepostResult}
+                className="text-gray-400 hover:text-gray-600"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            {/* nevent link */}
+            <div className="mb-4">
+              <p className="text-sm text-gray-500 mb-1">Event link</p>
+              <a
+                href={`https://njump.me/${repostResult.nevent}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-bitcoin-orange hover:underline break-all"
+              >
+                {repostResult.nevent}
+              </a>
+            </div>
+
+            {/* Relays published to */}
+            <div>
+              <p className="text-sm text-gray-500 mb-1">Published to relays:</p>
+              <ul className="text-xs text-gray-600 space-y-0.5">
+                {repostResult.relays.map((r) => (
+                  <li key={r} className="font-mono">{r}</li>
+                ))}
+              </ul>
+            </div>
+
+            <button
+              onClick={closeRepostResult}
+              className="mt-4 w-full py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 text-sm font-medium transition-colors"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* Zap modal */}
-      {showZap && signEvent && (
+      {showZap && (
         <ZapModal
           event={event}
           isOpen={showZap}
           onClose={() => setShowZap(false)}
           signEvent={signEvent}
           pubkey={pubkey ?? null}
+          onZapConfirmed={() => setZapRefreshKey((k) => k + 1)}
         />
       )}
     </div>

--- a/src/components/ZapModal.tsx
+++ b/src/components/ZapModal.tsx
@@ -1,22 +1,27 @@
 /**
  * ZapModal — NIP-57 zap amount picker and payment flow.
- * Preset amounts, custom input, WebLN payment, and QR code fallback.
+ * Preset amounts, custom input, WebLN payment, QR code fallback,
+ * and relay-based payment confirmation via kind 9735 zap receipts.
  */
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import QRCode from "qrcode";
 import { useModal } from "@/hooks/useModal";
 import { fetchZapInvoice, type SignerFn } from "@/utils/zaps";
+import { generateKeyPair } from "@/utils/bech32";
+import { pool } from "@/lib/nostr";
+import { nostrRelays } from "@/config";
 
-const PRESETS = [100, 500, 1000, 5000];
+const PRESETS = [21, 69, 420, 3333];
 
-type Step = "pick" | "loading" | "pay" | "success" | "error";
+type Step = "pick" | "loading" | "pay" | "confirming" | "success" | "error";
 
 interface ZapModalProps {
   event: Record<string, unknown>;
   isOpen: boolean;
   onClose: () => void;
-  signEvent: SignerFn;
+  signEvent?: SignerFn;
   pubkey: string | null;
+  onZapConfirmed?: () => void;
 }
 
 export default function ZapModal({
@@ -25,8 +30,9 @@ export default function ZapModal({
   onClose,
   signEvent,
   pubkey,
+  onZapConfirmed,
 }: ZapModalProps) {
-  const [amount, setAmount] = useState(1000);
+  const [amount, setAmount] = useState(21);
   const [customInput, setCustomInput] = useState("");
   const [isCustom, setIsCustom] = useState(false);
   const [step, setStep] = useState<Step>("pick");
@@ -35,6 +41,12 @@ export default function ZapModal({
   const [errorMsg, setErrorMsg] = useState("");
   const [hasWebln, setHasWebln] = useState(false);
   const [copied, setCopied] = useState(false);
+  // The signed kind 9734 zap request event (shown for anonymous zaps)
+  const [signedZapRequest, setSignedZapRequest] = useState<Record<string, unknown> | null>(null);
+  // Track whether the logged-in user is anonymous
+  const [isAnonymous, setIsAnonymous] = useState(false);
+  // Ref to cancel the zap receipt subscription
+  const zapSubRef = useRef<{ unsubscribe: () => void } | null>(null);
 
   useModal(isOpen, onClose);
 
@@ -47,17 +59,104 @@ export default function ZapModal({
   useEffect(() => {
     if (isOpen) {
       setStep("pick");
-      setAmount(1000);
+      setAmount(21);
       setCustomInput("");
       setIsCustom(false);
       setInvoice(null);
       setQrDataUrl(null);
       setErrorMsg("");
       setCopied(false);
+      setSignedZapRequest(null);
+      setIsAnonymous(false);
     }
   }, [isOpen]);
 
+  // Clean up zap receipt subscription on unmount or close
+  useEffect(() => {
+    return () => {
+      if (zapSubRef.current) {
+        zapSubRef.current.unsubscribe();
+        zapSubRef.current = null;
+      }
+    };
+  }, [isOpen]);
+
   const activeAmount = isCustom ? parseInt(customInput, 10) || 0 : amount;
+  const eventId = event.id as string | undefined;
+
+  /**
+   * Open a live subscription for kind 9735 zap receipts matching our invoice.
+   * Uses pool.subscription (stays open) instead of pool.request (one-shot).
+   * Matches by exact bolt11 invoice to avoid false positives from old zaps.
+   */
+  const watchForZapReceipt = useCallback((millisats: number, bolt11: string) => {
+    if (!eventId) return;
+
+    // Clean up any existing subscription
+    if (zapSubRef.current) {
+      zapSubRef.current.unsubscribe();
+    }
+
+    const sub = pool
+      .subscription(nostrRelays, {
+        kinds: [9735],
+        "#e": [eventId],
+        limit: 100,
+      })
+      .subscribe({
+        next: (receipt: any) => {
+          // Match by exact bolt11 invoice — ignores old receipts with different invoices
+          const bolt11Tag = receipt.tags?.find((t: string[]) => t[0] === "bolt11");
+          if (bolt11Tag?.[1] === bolt11) {
+            setStep("success");
+            sub.unsubscribe();
+            zapSubRef.current = null;
+            onZapConfirmed?.();
+          }
+        },
+        error: () => {},
+        complete: () => {},
+      });
+
+    zapSubRef.current = sub;
+
+    // Timeout after 3 minutes — stop watching
+    setTimeout(() => {
+      sub.unsubscribe();
+      if (zapSubRef.current === sub) {
+        zapSubRef.current = null;
+      }
+    }, 180_000);
+  }, [eventId]);
+
+  // Get a signer — use the provided one when logged in, else generate a throwaway key
+  const getSigner = useCallback(async (): Promise<{ signer: SignerFn; anonymous: boolean }> => {
+    if (signEvent && pubkey) return { signer: signEvent, anonymous: false };
+    // Generate a throwaway keypair for anonymous zaps
+    const { privkeyHex } = await generateKeyPair();
+    const schnorr = (await import("@noble/curves/secp256k1.js")).schnorr;
+    // hex → Uint8Array
+    const privBytes = new Uint8Array(privkeyHex.length / 2);
+    for (let i = 0; i < privkeyHex.length; i += 2) {
+      privBytes[i / 2] = parseInt(privkeyHex.substring(i, i + 2), 16);
+    }
+    const anonSigner: SignerFn = async (evt) => {
+      const serialized = JSON.stringify([0, evt.kind, evt.tags, evt.content]);
+      const msgBytes = new TextEncoder().encode(serialized);
+      const hashBytes = new Uint8Array(await crypto.subtle.digest("SHA-256", msgBytes));
+      const sig = schnorr.sign(hashBytes, privBytes);
+      const pubKey = schnorr.getPublicKey(privBytes);
+      const idHash = new Uint8Array(await crypto.subtle.digest("SHA-256", msgBytes));
+      const toHex = (b: Uint8Array) => Array.from(b).map(x => x.toString(16).padStart(2, "0")).join("");
+      return {
+        ...evt,
+        id: toHex(idHash),
+        pubkey: toHex(pubKey),
+        sig: toHex(sig),
+      };
+    };
+    return { signer: anonSigner, anonymous: true };
+  }, [signEvent]);
 
   const handleZap = useCallback(async () => {
     const millisats = activeAmount * 1000;
@@ -69,11 +168,14 @@ export default function ZapModal({
 
     setStep("loading");
 
+    const { signer, anonymous } = await getSigner();
+    setIsAnonymous(anonymous);
+
     const result = await fetchZapInvoice({
       recipientPubkey: event.pubkey as string,
       eventId: event.id as string | undefined,
       millisats,
-      signEvent,
+      signEvent: signer,
     });
 
     if ("error" in result) {
@@ -82,8 +184,16 @@ export default function ZapModal({
       return;
     }
 
+    // Capture the signed zap request for debugging display
+    if (result.signedRequest) {
+      setSignedZapRequest(result.signedRequest);
+    }
+
     const bolt11 = result.invoice;
     setInvoice(bolt11);
+
+    // Start watching for zap receipt (kind 9735) on relays
+    watchForZapReceipt(millisats, bolt11);
 
     // Try WebLN first
     if (window.webln) {
@@ -91,7 +201,7 @@ export default function ZapModal({
         await window.webln.enable();
         await window.webln.sendPayment(bolt11);
         setStep("success");
-        setTimeout(onClose, 1500);
+        onZapConfirmed?.();
         return;
       } catch {
         // WebLN failed or cancelled — fall through to QR
@@ -110,7 +220,7 @@ export default function ZapModal({
       // QR generation failed — still show invoice text
     }
     setStep("pay");
-  }, [activeAmount, event, signEvent, onClose]);
+  }, [activeAmount, event, getSigner, watchForZapReceipt]);
 
   const handleCopyInvoice = useCallback(async () => {
     if (!invoice) return;
@@ -131,7 +241,7 @@ export default function ZapModal({
       onClick={onClose}
     >
       <div
-        className="bg-white rounded-lg shadow-2xl max-w-md w-full p-6"
+        className="bg-white rounded-lg shadow-2xl max-w-md w-full p-6 max-h-[90vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
@@ -140,7 +250,8 @@ export default function ZapModal({
             {step === "pick" && `Zap ${activeAmount} sats`}
             {step === "loading" && "Fetching invoice..."}
             {step === "pay" && `Pay ${activeAmount} sats`}
-            {step === "success" && "Zap sent!"}
+            {step === "confirming" && "Confirming zap..."}
+            {step === "success" && "Zap confirmed!"}
             {step === "error" && "Zap failed"}
           </h3>
           <button
@@ -156,11 +267,6 @@ export default function ZapModal({
         {/* Step: Pick amount */}
         {step === "pick" && (
           <>
-            {!pubkey && (
-              <p className="text-sm text-yellow-700 mb-4">
-                You need to log in to send zaps.
-              </p>
-            )}
             <div className="grid grid-cols-4 gap-2 mb-4">
               {PRESETS.map((preset) => (
                 <button
@@ -196,7 +302,7 @@ export default function ZapModal({
             </div>
             <button
               onClick={handleZap}
-              disabled={!pubkey || activeAmount <= 0}
+              disabled={activeAmount <= 0}
               className="w-full py-2.5 bg-bitcoin-orange text-white rounded-lg hover:bg-orange-600 disabled:opacity-50 font-semibold transition-colors"
             >
               Zap {activeAmount} sats
@@ -220,15 +326,30 @@ export default function ZapModal({
                 <img src={qrDataUrl} alt="Lightning invoice QR code" className="w-64 h-64" />
               </div>
             )}
-            <p className="text-sm text-gray-600 mb-3">
+            <p className="text-sm text-gray-600 mb-1">
               Scan with your Lightning wallet
+            </p>
+            <p className="text-xs text-gray-400 mb-3">
+              Watching relays for payment confirmation...
             </p>
             <button
               onClick={handleCopyInvoice}
-              className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 text-sm font-medium transition-colors"
+              className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 text-sm font-medium transition-colors mb-4"
             >
               {copied ? "Copied!" : "Copy Invoice"}
             </button>
+
+            {/* Anonymous zap: show signed kind 9734 zap request for debugging */}
+            {isAnonymous && signedZapRequest && (
+              <details className="w-full">
+                <summary className="text-xs text-gray-400 cursor-pointer hover:text-gray-600 mb-2">
+                  Debug: signed zap request (kind 9734)
+                </summary>
+                <pre className="text-xs text-gray-600 bg-gray-50 rounded-lg p-3 overflow-auto whitespace-pre-wrap break-all max-h-48 border border-gray-200">
+                  {JSON.stringify(signedZapRequest, null, 2)}
+                </pre>
+              </details>
+            )}
           </div>
         )}
 
@@ -236,7 +357,20 @@ export default function ZapModal({
         {step === "success" && (
           <div className="flex flex-col items-center py-6">
             <div className="text-4xl mb-2">&#x26A1;</div>
-            <p className="text-gray-700 font-medium">Zap sent!</p>
+            <p className="text-gray-700 font-medium mb-1">Zap confirmed!</p>
+            <p className="text-xs text-gray-400">Payment verified on relays</p>
+
+            {/* Anonymous zap: show signed zap request on success too */}
+            {isAnonymous && signedZapRequest && (
+              <details className="w-full mt-4">
+                <summary className="text-xs text-gray-400 cursor-pointer hover:text-gray-600 mb-2">
+                  Debug: signed zap request (kind 9734)
+                </summary>
+                <pre className="text-xs text-gray-600 bg-gray-50 rounded-lg p-3 overflow-auto whitespace-pre-wrap break-all max-h-48 border border-gray-200">
+                  {JSON.stringify(signedZapRequest, null, 2)}
+                </pre>
+              </details>
+            )}
           </div>
         )}
 

--- a/src/pages/education.tsx
+++ b/src/pages/education.tsx
@@ -5,7 +5,7 @@ import { kinds, unixNow } from "applesauce-core/helpers";
 import { use$ } from "applesauce-react/hooks";
 import { onlyEvents } from "applesauce-relay/operators";
 import Head from "next/head";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeSanitize from "rehype-sanitize";
 import EventActions from "@/components/EventActions";
@@ -44,6 +44,7 @@ import {
   publishPin,
   publishPinboard,
 } from "@/utils/pinboardEvents";
+import { fetchZapTotal } from "@/utils/zaps";
 import { eventStore, pool } from "../lib/nostr";
 
 function getYouTubeId(url: string): string | null {
@@ -117,8 +118,33 @@ export default function EducationPage() {
   const [view, setView] = useState<"featured" | "boards">("featured");
   const [showAddPin, setShowAddPin] = useState(false);
   const [editPin, setEditPin] = useState<Pin | null>(null);
-  const [sortBy, setSortBy] = useState<"date" | "title">("date");
+  const [sortBy, setSortBy] = useState<"date" | "title" | "zaps">("date");
   const [selectedArticle, setSelectedArticle] = useState<Pin | null>(null);
+
+  // Zap totals for sorting — fetched once for visible pins
+  const [zapTotals, setZapTotals] = useState<Record<string, number>>({});
+  const prevPinIdsRef = useRef<string>("");
+
+  useEffect(() => {
+    // Build a stable key from current pin IDs to avoid re-fetching on every render
+    const pins = view === "featured" ? featuredPins : boardPins;
+    const ids = pins.map((p) => p.id).sort().join(",");
+    if (ids === prevPinIdsRef.current) return;
+    prevPinIdsRef.current = ids;
+
+    let cancelled = false;
+    const totals: Record<string, number> = {};
+    Promise.all(
+      pins.map((p) =>
+        fetchZapTotal(p.id).then((t) => {
+          if (t > 0) totals[p.id] = t;
+        }),
+      ),
+    ).then(() => {
+      if (!cancelled) setZapTotals(totals);
+    });
+    return () => { cancelled = true; };
+  }, [view, featuredPins, boardPins]);
 
   const liveStreamFilters = useMemo(() => [
     {
@@ -251,6 +277,7 @@ export default function EducationPage() {
       ? activePins
       : activePins.filter((p) => getDisplayType(p) === displayFilter)
   ).sort((a, b) => {
+    if (sortBy === "zaps") return (zapTotals[b.id] || 0) - (zapTotals[a.id] || 0);
     if (sortBy === "title") return (a.title || "").localeCompare(b.title || "");
     return b.created_at - a.created_at; // date desc (newest first)
   });
@@ -654,8 +681,8 @@ function FilterBar({
   pins: Pin[];
   filter: DisplayType | "all";
   setFilter: (f: DisplayType | "all") => void;
-  sortBy: "date" | "title";
-  setSortBy: (s: "date" | "title") => void;
+  sortBy: "date" | "title" | "zaps";
+  setSortBy: (s: "date" | "title" | "zaps") => void;
   onAddClick: () => void;
   canAdd: boolean;
 }) {
@@ -703,7 +730,7 @@ function FilterBar({
         data-testid="sort-controls"
       >
         <span className="text-xs text-gray-500 mr-1">Sort:</span>
-        {(["date", "title"] as const).map((s) => (
+        {(["date", "title", "zaps"] as const).map((s) => (
           <button
             key={s}
             data-testid={`sort-${s}`}
@@ -714,7 +741,7 @@ function FilterBar({
                 : "bg-gray-100 text-gray-600 hover:bg-gray-200"
             }`}
           >
-            {s === "date" ? "Newest" : "A-Z"}
+            {s === "date" ? "Newest" : s === "title" ? "A-Z" : "\u26A1 Zaps"}
           </button>
         ))}
       </div>
@@ -739,6 +766,80 @@ interface PodcastFeedMeta {
 
 const feedMetaCache = new Map<string, PodcastFeedMeta>();
 
+// CORS proxy list — tried in order after direct fetch fails
+const CORS_PROXIES = [
+  (url: string) => `https://api.codetabs.com/v1/proxy/?quest=${encodeURIComponent(url)}`,
+  (url: string) => `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`,
+];
+
+/**
+ * Try to fetch RSS feed content. Attempts direct fetch first (some servers
+ * allow CORS), then falls back to CORS proxies. Returns raw XML text or null.
+ */
+async function fetchFeedXml(feedUrl: string, signal?: AbortSignal): Promise<string | null> {
+  // Try direct fetch first — many podcast hosts set Access-Control-Allow-Origin
+  try {
+    const res = await fetch(feedUrl, { signal, mode: "cors" });
+    if (res.ok) {
+      const text = await res.text();
+      if (text.length > 100 && (text.includes("<rss") || text.includes("<feed"))) {
+        return text;
+      }
+    }
+  } catch {
+    // Direct fetch blocked by CORS — fall through to proxies
+  }
+
+  // Fall back to CORS proxies
+  for (const proxyFn of CORS_PROXIES) {
+    try {
+      const res = await fetch(proxyFn(feedUrl), { signal });
+      if (!res.ok) continue;
+      const text = await res.text();
+      if (text.length > 100 && (text.includes("<rss") || text.includes("<feed"))) {
+        return text;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+/**
+ * Heuristic: derive a website URL from a feed URL when the feed can't be fetched.
+ * e.g. "https://feed.homegrownhits.xyz/feed.xml" → "https://homegrownhits.xyz"
+ */
+function deriveWebsiteFromFeedUrl(feedUrl: string): string | null {
+  try {
+    const url = new URL(feedUrl);
+    const host = url.hostname;
+    // Strip common feed prefixes: "feed.", "rss.", "podcast.", "feeds."
+    const stripped = host.replace(/^(feed|feeds|rss|podcast|cdn)\./, "");
+    // Don't return anything if it still looks like a CDN or generic domain
+    if (stripped.includes(".xyz") || stripped.includes(".com") || stripped.includes(".io")) {
+      return `https://${stripped}`;
+    }
+    return `https://${stripped}`;
+  } catch {
+    return null;
+  }
+}
+
+function parseFeedMeta(xml: string): PodcastFeedMeta {
+  let imageUrl: string | null = null;
+  let websiteUrl: string | null = null;
+  const imgMatch = xml.match(/<itunes:image[^>]*href=["']([^"']+)["']/i);
+  if (imgMatch) imageUrl = imgMatch[1];
+  if (!imageUrl) {
+    const imgTagMatch = xml.match(/<image>[\s\S]*?<url>([^<]+)<\/url>/i);
+    if (imgTagMatch) imageUrl = imgTagMatch[1].trim();
+  }
+  const linkMatch = xml.match(/<channel[\s\S]*?<link>([^<]+)<\/link>/i);
+  if (linkMatch) websiteUrl = linkMatch[1].trim();
+  return { imageUrl, websiteUrl };
+}
+
 function usePodcastFeedMeta(feedUrl: string | null): PodcastFeedMeta | null {
   const [meta, setMeta] = useState<PodcastFeedMeta | null>(null);
 
@@ -752,24 +853,21 @@ function usePodcastFeedMeta(feedUrl: string | null): PodcastFeedMeta | null {
       return;
     }
     const controller = new AbortController();
-    // Use CORS proxy since static export can't have API routes
-    const proxyUrl = `https://api.codetabs.com/v1/proxy/?quest=${encodeURIComponent(feedUrl)}`;
-    fetch(proxyUrl, { signal: controller.signal })
-      .then((r) => r.text())
+    fetchFeedXml(feedUrl, controller.signal)
       .then((xml) => {
-        let imageUrl: string | null = null;
-        let websiteUrl: string | null = null;
-        const imgMatch = xml.match(/<itunes:image[^>]*href=["']([^"']+)["']/i);
-        if (imgMatch) imageUrl = imgMatch[1];
-        if (!imageUrl) {
-          const imgTagMatch = xml.match(/<image>[\s\S]*?<url>([^<]+)<\/url>/i);
-          if (imgTagMatch) imageUrl = imgTagMatch[1].trim();
+        if (xml) {
+          const result = parseFeedMeta(xml);
+          feedMetaCache.set(feedUrl, result);
+          setMeta(result);
+        } else {
+          // Feed couldn't be fetched — try deriving website URL from feed URL
+          const fallbackUrl = deriveWebsiteFromFeedUrl(feedUrl);
+          if (fallbackUrl) {
+            const fallback: PodcastFeedMeta = { imageUrl: null, websiteUrl: fallbackUrl };
+            feedMetaCache.set(feedUrl, fallback);
+            setMeta(fallback);
+          }
         }
-        const linkMatch = xml.match(/<channel[\s\S]*?<link>([^<]+)<\/link>/i);
-        if (linkMatch) websiteUrl = linkMatch[1].trim();
-        const result: PodcastFeedMeta = { imageUrl, websiteUrl };
-        feedMetaCache.set(feedUrl, result);
-        setMeta(result);
       })
       .catch(() => {});
     return () => controller.abort();

--- a/src/utils/bech32.ts
+++ b/src/utils/bech32.ts
@@ -112,3 +112,45 @@ export function naddrEncode(opts: {
 
   return bech32.encode("naddr", bech32.toWords(buf), 5000);
 }
+
+/** Encode a nostr event (nevent) per NIP-19. */
+export function neventEncode(opts: {
+  id: string;
+  relays?: string[];
+  author?: string;
+  kind?: number;
+}): string {
+  const tlv: { type: number; value: Uint8Array }[] = [];
+
+  // Type 0: event id (32 bytes)
+  tlv.push({ type: 0, value: hexToBytes(opts.id) });
+  // Type 1: relays
+  if (opts.relays) {
+    for (const relay of opts.relays) {
+      tlv.push({ type: 1, value: new TextEncoder().encode(relay) });
+    }
+  }
+  // Type 2: author (pubkey hex → 32 bytes)
+  if (opts.author) {
+    tlv.push({ type: 2, value: hexToBytes(opts.author) });
+  }
+  // Type 3: kind (4-byte big-endian)
+  if (opts.kind !== undefined) {
+    const kindBytes = new Uint8Array(4);
+    new DataView(kindBytes.buffer).setUint32(0, opts.kind, false);
+    tlv.push({ type: 3, value: kindBytes });
+  }
+
+  // Encode TLV
+  const totalLen = tlv.reduce((sum, e) => sum + 2 + e.value.length, 0);
+  const buf = new Uint8Array(totalLen);
+  let offset = 0;
+  for (const e of tlv) {
+    buf[offset++] = e.type;
+    buf[offset++] = e.value.length;
+    buf.set(e.value, offset);
+    offset += e.value.length;
+  }
+
+  return bech32.encode("nevent", bech32.toWords(buf), 5000);
+}

--- a/src/utils/zaps.ts
+++ b/src/utils/zaps.ts
@@ -206,7 +206,7 @@ export async function fetchZapInvoice(
     signEvent: SignerFn;
     content?: string;
   },
-): Promise<{ invoice: string } | { error: string }> {
+): Promise<{ invoice: string; signedRequest?: Record<string, unknown> } | { error: string }> {
   const { recipientPubkey, eventId, millisats, signEvent, content } = params;
 
   // Step 1: Get lightning address from profile
@@ -252,7 +252,7 @@ export async function fetchZapInvoice(
     if (!res.ok) return { error: `Lightning server error (${res.status}).` };
     const data = await res.json();
     if (!data.pr) return { error: "Invalid response from Lightning server." };
-    return { invoice: data.pr as string };
+    return { invoice: data.pr as string, signedRequest: signed };
   } catch {
     return { error: "Could not fetch payment invoice." };
   }
@@ -261,4 +261,85 @@ export async function fetchZapInvoice(
 /** Clear the LNURL cache (useful for testing). */
 export function clearLNURLCache(): void {
   lnurlCache.clear();
+}
+
+// ── Zap Totals ─────────────────────────────────────────────────────────
+
+/**
+ * Extract zap amount in sats from a kind 9735 zap receipt event.
+ * Tries the bolt11 invoice first, falls back to description tag.
+ */
+function extractZapAmount(event: any): number {
+  // Try bolt11 tag — parse millisats from the invoice
+  const bolt11Tag = event.tags?.find((t: string[]) => t[0] === "bolt11");
+  if (bolt11Tag?.[1]) {
+    // Try parsing amount= from invoice
+    const msatMatch = bolt11Tag[1].match(/amount=(\d+)/);
+    if (msatMatch) return Math.floor(parseInt(msatMatch[1]) / 1000);
+
+    // Fallback: amount from invoice prefix (e.g. "lnbc1u" = 100k msats)
+    try {
+      const invoice = bolt11Tag[1];
+      if (invoice.includes("lnbc")) {
+        const m = invoice.match(/(\d+)([munp])/);
+        if (m) {
+          const amt = parseInt(m[1]);
+          switch (m[2]) {
+            case "p": return Math.floor(amt * 1000);
+            case "n": return Math.floor(amt / 10);
+            case "u": return Math.floor(amt * 100);
+            case "m": return Math.floor(amt * 100000);
+          }
+        }
+      }
+    } catch { /* ignore */ }
+  }
+
+  // Try amount tag
+  const amountTag = event.tags?.find((t: string[]) => t[0] === "amount");
+  if (amountTag?.[1]) {
+    const msats = parseInt(amountTag[1]);
+    if (!isNaN(msats)) return Math.floor(msats / 1000);
+  }
+
+  return 0;
+}
+
+/**
+ * Fetch the total zap amount (in sats) received by a specific event.
+ * Queries relays for kind 9735 zap receipts referencing the event ID.
+ * Deduplicates across relays by event ID.
+ */
+export function fetchZapTotal(eventId: string): Promise<number> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let total = 0;
+    const seen = new Set<string>();
+
+    const sub = pool
+      .request(nostrRelays, {
+        kinds: [9735],
+        "#e": [eventId],
+        limit: 500,
+      })
+      .subscribe({
+        next: (event: any) => {
+          if (seen.has(event.id)) return;
+          seen.add(event.id);
+          total += extractZapAmount(event);
+        },
+        error: () => {
+          if (!settled) { settled = true; resolve(total); }
+        },
+        complete: () => {
+          if (!settled) { settled = true; resolve(total); }
+        },
+      });
+
+    // Timeout after 5s — return whatever we collected
+    setTimeout(() => {
+      if (!settled) { settled = true; resolve(total); }
+      sub.unsubscribe();
+    }, 5000);
+  });
 }


### PR DESCRIPTION
- Add NIP-18 generic repost (kind 16) to EventActions kebab menu
- Show repost success popup with relay list and nevent link
- Add zap total badge (⚡ amount) under kebab button
- Allow zapping when logged out (throwaway keypair + QR)
- Confirm zap via live kind 9735 subscription on relays
- Show signed zap request JSON for anonymous zaps (debug)
- Refresh zap total badge after confirmed zap
- Gate edit/delete on event ownership (pubkey match)
- Add sort by zaps on education page
- Change zap presets to 21, 69, 420, 3333
- Fix podcast RSS feed resolution (direct fetch first, heuristic fallback)