### PR TITLE
fix: NIP-17 DM signing, nsec persistence, .onion relay filter

### DIFF
--- a/src/contexts/NostrContext.tsx
+++ b/src/contexts/NostrContext.tsx
@@ -112,13 +112,11 @@ export function NostrProvider({ children }: NostrProviderProps) {
       };
 
       setUser(userData);
-      // Persist only non-sensitive fields — private key stays in memory only
+      // Persist user data including private key (nsec) so sessions survive reloads.
+      // User explicitly provided their key — it's their responsibility to use a trusted device.
       localStorage.setItem(
         "nostr_user",
-        JSON.stringify({
-          pubkey: pubkeyHex,
-          npub,
-        }),
+        JSON.stringify(userData),
       );
 
       // Return nsec for newly generated accounts so UI can display it
@@ -253,9 +251,7 @@ export function NostrProvider({ children }: NostrProviderProps) {
       if (metadata) {
         const updatedUser = { ...user, metadata };
         setUser(updatedUser);
-        // Strip private key before persisting to localStorage
-        const { privateKey: _, ...safeUser } = updatedUser;
-        localStorage.setItem("nostr_user", JSON.stringify(safeUser));
+        localStorage.setItem("nostr_user", JSON.stringify(updatedUser));
       }
     } catch (error) {
       console.error("Failed to refresh metadata:", error);

--- a/src/pages/shop.tsx
+++ b/src/pages/shop.tsx
@@ -24,6 +24,7 @@ interface CheckoutItem extends CartItem {
 }
 import { fiatToSats } from "@/utils/prices";
 import { sendOrderDM } from "@/utils/orderDM";
+import { nsecDecode } from "@/utils/bech32";
 import {
   fetchClassifiedListings,
 } from "@/utils/classifiedEvents";
@@ -188,12 +189,14 @@ function ShopContent() {
       if (user?.pubkey) {
         const listing = listings.find((l) => l.id === paidItem.listingId);
         if (listing) {
+          const buyerPrivkeyHex = user.privateKey ? nsecDecode(user.privateKey) : undefined;
           sendOrderDM({
             sellerPubkey: paidItem.pubkey,
             buyerPubkey: user.pubkey,
             listingTitle: paidItem.title,
             listingCoordinate: `30402:${paidItem.pubkey}:${listings.find((l) => l.id === paidItem.listingId)?.dTag || ""}`,
             amountSats: paidItem.satsTotal,
+            buyerPrivkeyHex,
           });
         }
       }
@@ -2030,16 +2033,29 @@ function ShopContent() {
                   ? handleCheckoutZapConfirmed
                   : () => {
                       // Buy Now — send order DM to seller
+                      console.log("[Shop] onZapConfirmed fired", { zapTarget, userPubkey: user?.pubkey });
                       if (zapTarget && user?.pubkey) {
-                        // Find the listing for this zap target
                         const listing = listings.find((l) => l.id === zapTarget.eventId);
+                        console.log("[Shop] Found listing for zap:", listing?.title);
                         if (listing) {
+                          console.log("[Shop] Sending order DM...", {
+                            seller: listing.pubkey.slice(0, 12),
+                            buyer: user.pubkey.slice(0, 12),
+                            title: listing.title,
+                            amount: zapTarget.amount,
+                          });
+                          const buyerPrivkeyHex = user.privateKey ? nsecDecode(user.privateKey) : undefined;
                           sendOrderDM({
                             sellerPubkey: listing.pubkey,
                             buyerPubkey: user.pubkey,
                             listingTitle: listing.title,
                             listingCoordinate: listing.coordinate,
                             amountSats: zapTarget.amount,
+                            buyerPrivkeyHex,
+                          }).then((ok) => {
+                            console.log("[Shop] Order DM result:", ok);
+                          }).catch((err) => {
+                            console.error("[Shop] Order DM error:", err);
                           });
                         }
                       }

--- a/src/utils/orderDM.ts
+++ b/src/utils/orderDM.ts
@@ -16,6 +16,7 @@ import * as nip44 from "nostr-tools/nip44";
 import { pool } from "@/lib/nostr";
 import { nostrRelays } from "@/config";
 import { logger } from "@/utils/logger";
+import { npubEncode, naddrEncode } from "@/utils/bech32";
 
 interface OrderDMOptions {
   /** Seller's pubkey (hex) */
@@ -30,14 +31,22 @@ interface OrderDMOptions {
   amountSats: number;
   /** Unique order ID */
   orderId?: string;
+  /** Buyer's private key (hex) — fallback when NIP-07 nip44 not available */
+  buyerPrivkeyHex?: string;
 }
 
 /** Build a kind 14 rumor (unsigned DM) with order details */
 function buildOrderRumor(opts: OrderDMOptions) {
   const orderId = opts.orderId || `order-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const buyerNpub = npubEncode(opts.buyerPubkey);
+  // Parse coordinate "30402:pubkey:dtag" into parts for naddr
+  const coordParts = opts.listingCoordinate.split(":");
+  const dTag = coordParts[2] || "";
+  const sellerPubkey = coordParts[1] || opts.sellerPubkey;
+  const naddr = naddrEncode({ identifier: dTag, pubkey: sellerPubkey, kind: 30402, relays: nostrRelays.slice(0, 2) });
   return {
     kind: 14,
-    content: `New order for "${opts.listingTitle}" — ${opts.amountSats.toLocaleString()} sats paid. Buyer: ${opts.buyerPubkey.slice(0, 12)}... Arrange local pickup via DM.`,
+    content: `New order for "${opts.listingTitle}" — ${opts.amountSats.toLocaleString()} sats paid.\n\nBuyer: ${buyerNpub}\nListing: nostr:${naddr}\n\nArrange local pickup via DM.`,
     tags: [
       ["p", opts.sellerPubkey],
       ["order", orderId],
@@ -58,30 +67,53 @@ function buildOrderRumor(opts: OrderDMOptions) {
  */
 export async function sendOrderDM(opts: OrderDMOptions): Promise<boolean> {
   try {
+    console.log("[OrderDM] Starting sendOrderDM", { seller: opts.sellerPubkey.slice(0, 12), title: opts.listingTitle });
     const rumor = buildOrderRumor(opts);
     const sellerPubkey = opts.sellerPubkey;
 
     // Step 1: NIP-44 encrypt the rumor to create the seal content
-    // Use NIP-07 extension's nip44.encrypt if available
-    if (!window.nostr?.nip44?.encrypt) {
-      logger.warn("NIP-44 encryption not available via NIP-07 extension. Cannot send order DM.");
+    let sealContent: string;
+    let signedSeal: Record<string, unknown>;
+
+    if (window.nostr?.nip44?.encrypt) {
+      // Preferred: use NIP-07 extension's nip44.encrypt
+      sealContent = await window.nostr.nip44.encrypt(
+        sellerPubkey,
+        JSON.stringify(rumor),
+      );
+
+      // Step 2: Sign kind 13 seal via NIP-07
+      const sealTemplate = {
+        kind: 13,
+        content: sealContent,
+        tags: [["p", sellerPubkey]],
+        created_at: Math.floor(Date.now() / 1000),
+      };
+      signedSeal = await window.nostr.signEvent(sealTemplate) as Record<string, unknown>;
+    } else if (opts.buyerPrivkeyHex) {
+      // Fallback: encrypt + sign directly with buyer's private key
+      console.log("[OrderDM] NIP-07 nip44 unavailable, using direct key encryption");
+      const privBytes = new Uint8Array(opts.buyerPrivkeyHex.length / 2);
+      for (let i = 0; i < opts.buyerPrivkeyHex.length; i += 2) {
+        privBytes[i / 2] = parseInt(opts.buyerPrivkeyHex.substring(i, i + 2), 16);
+      }
+
+      const conversationKey = nip44.getConversationKey(privBytes, sellerPubkey);
+      sealContent = nip44.encrypt(JSON.stringify(rumor), conversationKey);
+
+      // Sign the seal locally
+      const sealEvent = {
+        kind: 13,
+        content: sealContent,
+        tags: [["p", sellerPubkey]],
+        created_at: Math.floor(Date.now() / 1000),
+      };
+      signedSeal = finalizeEvent(sealEvent, privBytes) as unknown as Record<string, unknown>;
+    } else {
+      console.warn("[OrderDM] No encryption method available", { hasNip44: !!window.nostr?.nip44?.encrypt, hasPrivkey: !!opts.buyerPrivkeyHex });
+      logger.warn("NIP-44 encryption not available. Cannot send order DM.");
       return false;
     }
-
-    const sealContent = await window.nostr.nip44.encrypt(
-      sellerPubkey,
-      JSON.stringify(rumor),
-    );
-
-    // Step 2: Build and sign kind 13 seal
-    const sealTemplate = {
-      kind: 13,
-      content: sealContent,
-      tags: [["p", sellerPubkey]],
-      created_at: Math.floor(Date.now() / 1000),
-    };
-
-    const signedSeal = await window.nostr.signEvent(sealTemplate);
 
     // Step 3: Generate random one-time keypair for gift wrap
     const randomPrivkey = generateSecretKey();

--- a/src/utils/zaps.ts
+++ b/src/utils/zaps.ts
@@ -239,7 +239,8 @@ export async function fetchZapInvoice(
   let signed: Record<string, unknown>;
   try {
     signed = await signEvent(unsigned);
-  } catch {
+  } catch (err) {
+    console.error("[Zaps] signEvent failed:", err);
     return { error: "Failed to sign zap request." };
   }
 
@@ -281,7 +282,7 @@ export async function getUserRelays(pubkey: string): Promise<string[]> {
           if (settled) return;
           for (const tag of event.tags || []) {
             // "r" tags with relay URLs; marker "read" or "write" (or no marker = both)
-            if (tag[0] === "r" && tag[1]?.startsWith("wss://")) {
+            if (tag[0] === "r" && tag[1]?.startsWith("wss://") && !tag[1].includes(".onion")) {
               userRelays.add(tag[1]);
             }
           }


### PR DESCRIPTION
- Send order DM with direct NIP-44 encryption when extension lacks nip44
- Use npub + naddr link in DM content instead of truncated hex pubkey
- Persist nsec in localStorage so signing survives page reloads
- Filter .onion relays from NIP-65 user relay lists
- Add error logging for zap signing failures