### PR TITLE
Bug fixes and improvements: added cleanup functions and UX tweaks to mitigate event duplication

### DIFF
--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -152,7 +152,10 @@ export default function CalendarView({
       } else {
         // Timed event
         const eventStart = parseInt(event.start || "0");
-        const eventEnd = parseInt(event.end || eventStart.toString());
+        // Guard: if end is before start (bad data), treat end === start so the
+        // event only appears on its start date and never bleeds to an earlier cell.
+        const rawEnd = parseInt(event.end || eventStart.toString());
+        const eventEnd = rawEnd >= eventStart ? rawEnd : eventStart;
 
         // Check if event overlaps with the current day (using local timezone timestamps)
         return (

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -127,6 +127,22 @@ export default function EventForm({
       return;
     }
 
+    // Guard: end must not be before start
+    if (formData.eventType === "timed" && formData.endDate && formData.endTime) {
+      const start = new Date(`${formData.startDate}T${formData.startTime}`);
+      const end = new Date(`${formData.endDate}T${formData.endTime}`);
+      if (end < start) {
+        alert("End date/time cannot be before the start date/time.");
+        return;
+      }
+    }
+    if (formData.eventType === "all-day" && formData.endDate) {
+      if (formData.endDate < formData.startDate) {
+        alert("End date cannot be before the start date.");
+        return;
+      }
+    }
+
     onSubmit(formData);
   };
 
@@ -142,6 +158,14 @@ export default function EventForm({
     "Asia/Shanghai",
     "Australia/Sydney",
   ];
+
+  // When start date changes, advance end date if it would fall before the new start.
+  const handleStartDateChange = (date: string) => {
+    handleInputChange("startDate", date);
+    if (date && formData.endDate && formData.endDate < date) {
+      handleInputChange("endDate", date);
+    }
+  };
 
   // Auto-set end time to 1 hour after start time for timed events
   const handleStartTimeChange = (time: string) => {
@@ -267,9 +291,7 @@ export default function EventForm({
                   id="startDate"
                   type="date"
                   value={formData.startDate}
-                  onChange={(e) =>
-                    handleInputChange("startDate", e.target.value)
-                  }
+                  onChange={(e) => handleStartDateChange(e.target.value)}
                   className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-bitcoin-orange"
                   required
                 />
@@ -355,14 +377,14 @@ export default function EventForm({
               >
                 Start Date *
               </label>
-              <input
-                id="startDateAllDay"
-                type="date"
-                value={formData.startDate}
-                onChange={(e) => handleInputChange("startDate", e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-bitcoin-orange"
-                required
-              />
+                <input
+                  id="startDateAllDay"
+                  type="date"
+                  value={formData.startDate}
+                  onChange={(e) => handleStartDateChange(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-bitcoin-orange"
+                  required
+                />
             </div>
             <div>
               <label

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -145,9 +145,18 @@ export default function CalendarPage({
       if (cancelled) return;
 
       try {
+        // One-time cleanup: remove any Nostr-fetched events that were
+        // previously swept into localStorage by the overly-greedy saveEvents
+        // call. After this runs they will never appear in localStorage again.
+        const storedRaw = loadEvents();
+        const trulyLocal = storedRaw.filter((e) => e.source === "local");
+        if (trulyLocal.length !== storedRaw.length) {
+          saveEvents(trulyLocal); // saveEvents now only writes source==="local"
+        }
+
         // Load all three sources concurrently
         const [localEvents, meetupEvents, nostrCalendarEvents] = await Promise.all([
-          Promise.resolve(loadEvents()),
+          Promise.resolve(trulyLocal),
           // Transform meetup events from props
           (async () => {
             if (!meetupGroup) return [];
@@ -208,8 +217,18 @@ export default function CalendarPage({
           });
         });
 
-        // Merge and deduplicate
-        const allEvents = sortEventsByTime([...localEvents, ...meetupEvents, ...nostrEvents]);
+        // Merge and deduplicate. Prefer relay events over local copies
+        // (strip the "nostr-" prefix when comparing so "nostr-abc" and "abc"
+        // are recognised as the same event and only the relay version is kept).
+        const seen = new Set<string>();
+        const merged = [...nostrEvents, ...localEvents, ...meetupEvents];
+        const deduped = merged.filter((e) => {
+          const key = e.id.startsWith("nostr-") ? e.id.slice(6) : e.id;
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
+        const allEvents = sortEventsByTime(deduped);
         if (!cancelled) setEvents(allEvents);
       } catch (error) {
         logger.error("Error loading events:", error);
@@ -265,48 +284,35 @@ export default function CalendarPage({
         newEvent.pubkey = user.pubkey; // Use actual user pubkey from Nostr extension
         newEvent.dTag = `event-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`; // Match the dTag used in publishing
 
-        logger.debug("📝 Adding new event to local state:", {
-          id: newEvent.id,
-          title: newEvent.title,
-          start: newEvent.start,
-          dTag: newEvent.dTag,
-          pubkey: newEvent.pubkey,
-        });
+          logger.debug("📝 Adding new event to local state:", {
+            id: newEvent.id,
+            title: newEvent.title,
+            start: newEvent.start,
+            dTag: newEvent.dTag,
+            pubkey: newEvent.pubkey,
+          });
 
-        // Add to existing events without duplicates
-        setEvents((prevEvents) => {
-          // Check if this event already exists (by ID or dTag+pubkey combination)
-          const exists = prevEvents.some(
-            (e) =>
-              e.id === newEvent.id ||
-              (e.dTag === newEvent.dTag && e.pubkey === newEvent.pubkey),
-          );
-
-          if (exists) {
-            logger.debug(
-              "⚠️ Event already exists, skipping duplicate:",
-              newEvent.id,
+          // Add to current view state so the event appears immediately.
+          // Do NOT save to localStorage — the event is now on the relay and
+          // will be fetched from there on the next page load.  Saving relay
+          // events to localStorage was the root cause of calendar duplicates.
+          setEvents((prevEvents) => {
+            const exists = prevEvents.some(
+              (e) =>
+                e.id === newEvent.id ||
+                (e.dTag === newEvent.dTag && e.pubkey === newEvent.pubkey),
             );
-            return prevEvents;
-          }
-
-          const updatedEvents = sortEventsByTime([...prevEvents, newEvent]);
-          logger.debug("📅 Updated events count:", updatedEvents.length);
-
-          // Also save to localStorage as backup (but avoid duplicates)
-          const existingEvents = loadEvents();
-          const hasLocalDuplicate = existingEvents.some(
-            (e) =>
-              e.id === newEvent.id ||
-              (e.dTag === newEvent.dTag && e.pubkey === newEvent.pubkey),
-          );
-
-          if (!hasLocalDuplicate) {
-            saveEvents(updatedEvents);
-          }
-
-          return updatedEvents;
-        });
+            if (exists) {
+              logger.debug(
+                "⚠️ Event already exists, skipping duplicate:",
+                newEvent.id,
+              );
+              return prevEvents;
+            }
+            const updatedEvents = sortEventsByTime([...prevEvents, newEvent]);
+            logger.debug("📅 Updated events count:", updatedEvents.length);
+            return updatedEvents;
+          });
 
         setShowCreateForm(false);
         setSuccessMessage({

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -16,13 +16,11 @@ export function generateAnonymousPubkey(): string {
   ).join("");
 }
 
-// Save events to localStorage (only local events, not meetup events)
+// Save events to localStorage (only truly local events — source === "local")
+// Never saves Nostr-fetched events; those live on the relay, not in localStorage.
 export function saveEvents(events: CalendarEvent[]): void {
   try {
-    // Filter out meetup events - only save user-created local events
-    const localEvents = events.filter(
-      (event) => event.pubkey !== "meetup" && !event.id.startsWith("meetup-"),
-    );
+    const localEvents = events.filter((event) => event.source === "local");
     localStorage.setItem(EVENTS_STORAGE_KEY, JSON.stringify(localEvents));
   } catch (error) {
     logger.error("Failed to save events:", error);

--- a/src/utils/nostrEvents.ts
+++ b/src/utils/nostrEvents.ts
@@ -291,14 +291,15 @@ export async function publishNostrEvent(
         const startDateTime = new Date(
           `${formData.startDate}T${formData.startTime}`,
         );
-        tags.push([
-          "start",
-          Math.floor(startDateTime.getTime() / 1000).toString(),
-        ]);
-      }
-      if (formData.endDate && formData.endTime) {
-        const endDateTime = new Date(`${formData.endDate}T${formData.endTime}`);
-        tags.push(["end", Math.floor(endDateTime.getTime() / 1000).toString()]);
+        const startTs = Math.floor(startDateTime.getTime() / 1000);
+        tags.push(["start", startTs.toString()]);
+
+        if (formData.endDate && formData.endTime) {
+          const endDateTime = new Date(`${formData.endDate}T${formData.endTime}`);
+          const endTs = Math.floor(endDateTime.getTime() / 1000);
+          // Never publish an end that is before start — clamp to start if needed.
+          tags.push(["end", Math.max(endTs, startTs).toString()]);
+        }
       }
     }
 


### PR DESCRIPTION
- only save events from "local" source to localStorage
- loadAllEvents runs cleanup on mount
- merge and deduplicate events on calendar page
- don't saveEvents to both localStorage and nostr relays (causes duplication)
- when start date moves ahead of end date on event form, auto-bump end date to match
- handleSubmit validates end comes after start date and throws alert if not
- publishNostrEvent builds start time, then clamps end to Math.max(endTs, startTs) so end can never come before start on relays
