### PR TITLE
ci: schedule daily builds for fresh Meetup event data

### DIFF
--- a/.github/workflows/staticS3.yml
+++ b/.github/workflows/staticS3.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["master", "dev", "deployBug"]
   schedule:
-    - cron: "0 0 * * 1,3,6"
+    - cron: "0 0 * * *"
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Meetup API requires `Content-Type: application/json` which is blocked by CORS preflight — client-side fetch is not possible. Events are fetched at build time via `getStaticProps`.

Increase build frequency from 3x/week (Mon/Wed/Sat) to daily (midnight UTC) so meetup events stay fresher.