### PR TITLE
Add committee structures NIP spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,9 @@ The app uses Nostr relays as its database. All user-generated content (events, r
 | 30067       | Pinboards (resource collections) | [Custom NIP](https://nostrhub.io/naddr1qvzqqqrcvypzqr6k8l3vlhccpjcsgkrtjkrnx7dqc87ul0psr2qvsf2lx0g47quaqy2hwumn8ghj7un9d3shjtnyd968gmewwp6kyqqfwp5kucn0v9exgucdyp5hj) |
 | 39067       | Pins (resource links)            | [Custom NIP](https://nostrhub.io/naddr1qvzqqqrcvypzqr6k8l3vlhccpjcsgkrtjkrnx7dqc87ul0psr2qvsf2lx0g47quaqy2hwumn8ghj7un9d3shjtnyd968gmewwp6kyqqfwp5kucn0v9exgucdyp5hj) |
 | 31923       | Calendar events                  | NIP-52                      |
-| 39068-39071 | Committee structures             | Custom (community-specific) |
+| 30068       | Committees                       | [Custom NIP](https://nostrhub.io/naddr1qvzqqqrcvypzp4cd2qy32p9ejtgc8zpz4uj96hmt8gttstv30t9hjfxw7c0dft8wqy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qq2vdhk6mtfw36x2etn32mm2s) |
+| 39068       | Committee members                | [Custom NIP](https://nostrhub.io/naddr1qvzqqqrcvypzp4cd2qy32p9ejtgc8zpz4uj96hmt8gttstv30t9hjfxw7c0dft8wqy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qq2vdhk6mtfw36x2etn32mm2s) |
+| 39069       | Committee openings               | [Custom NIP](https://nostrhub.io/naddr1qvzqqqrcvypzp4cd2qy32p9ejtgc8zpz4uj96hmt8gttstv30t9hjfxw7c0dft8wqy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qq2vdhk6mtfw36x2etn32mm2s) |
 
 Users authenticate via a NIP-07 compatible browser extension (e.g., [nos2x](https://github.com/fiatjaf/nos2x), [Alby](https://getalby.com)). Publishing is restricted to whitelisted pubkeys defined in `config.json`.
 

--- a/nips/committee-structures.md
+++ b/nips/committee-structures.md
@@ -1,0 +1,212 @@
+# Committee Structures
+
+`draft` `optional`
+
+This NIP defines a committee management system for Nostr, enabling communities to create organizational structures with members, roles, and open positions. Committees use a multi-event architecture that separates board metadata from members and openings, allowing for flexible organizational management.
+
+## Motivation
+
+Bitcoin community groups (meetups, hack spaces, conferences) need lightweight organizational structures — committees with chairs, members, and open volunteer positions. Existing Nostr kinds don't provide a way to express these relationships.
+
+While NIP-51 lists can group pubkeys, they lack the semantics for roles (chair, vice-chair, member), open positions, and the committee metadata (meeting schedules, images, descriptions) that real-world organizations need.
+
+This NIP provides three event kinds that work together:
+
+- **Committee** (kind 30068) — The group itself (parameterized replaceable)
+- **Committee Member** (kind 39068) — A person belonging to a committee
+- **Committee Opening** (kind 39069) — An open position on a committee
+
+## Event Kinds
+
+### Kind 30068: Committee
+
+A parameterized replaceable event representing a committee or working group.
+
+**Required Tags:**
+
+| Tag | Description |
+| --- | --- |
+| `d` | Unique identifier (slug) for the committee |
+
+**Optional Tags:**
+
+| Tag | Description |
+| --- | --- |
+| `title` | Human-readable committee name |
+| `description` | Extended description of the committee's purpose |
+| `image` | Committee logo or cover image URL |
+| `meetingSchedule` | Recurring meeting schedule (free-form text, e.g. "2nd Thursday of each month at 7pm") |
+| `openings` | Number of open positions (integer as string) |
+| `t` | Hashtag for categorization (repeatable) |
+
+**Content:** Empty string or optional description text.
+
+**Example:**
+
+```json
+{
+  "kind": 30068,
+  "pubkey": "<committee-author-pubkey>",
+  "created_at": 1704067200,
+  "content": "Organizes monthly meetup logistics including venue, speakers, and refreshments.",
+  "tags": [
+    ["d", "events-committee"],
+    ["title", "Events Committee"],
+    ["description", "Organizes monthly meetup logistics"],
+    ["image", "https://example.com/events-committee.png"],
+    ["meetingSchedule", "1st Wednesday of each month at 6pm"],
+    ["openings", "3"],
+    ["t", "events"],
+    ["t", "meetup"]
+  ]
+}
+```
+
+**Committee Address Format:** `30068:<pubkey>:<d-tag>`
+
+### Kind 39068: Committee Member
+
+A regular event representing a person's membership in a committee. Each member is a separate event, enabling per-member role tracking and independent updates.
+
+**Required Tags:**
+
+| Tag | Description |
+| --- | --- |
+| `a` | Committee coordinate: `30068:<pubkey>:<d-tag>` |
+| `d` | Unique identifier for this membership record |
+| `role` | Member's role (e.g. `chair`, `vice-chair`, `member`) |
+| `name` | Display name of the member |
+
+**Optional Tags:**
+
+| Tag | Description |
+| --- | --- |
+| `email` | Contact email address |
+| `phone` | Contact phone number |
+| `p` | Nostr pubkey of the member (for linking to their Nostr identity) |
+
+**Content:** Empty string.
+
+**Example:**
+
+```json
+{
+  "kind": 39068,
+  "pubkey": "<committee-author-pubkey>",
+  "created_at": 1704067200,
+  "content": "",
+  "tags": [
+    ["a", "30068:<committee-pubkey>:events-committee"],
+    ["d", "alice-membership"],
+    ["role", "chair"],
+    ["name", "Alice"],
+    ["email", "alice@example.com"],
+    ["p", "<alice-nostr-pubkey>"]
+  ]
+}
+```
+
+### Kind 39069: Committee Opening
+
+A regular event representing an open position on a committee. Openings can be created and deleted independently of members.
+
+**Required Tags:**
+
+| Tag | Description |
+| --- | --- |
+| `a` | Committee coordinate: `30068:<pubkey>:<d-tag>` |
+| `d` | Unique identifier for this opening |
+| `title` | Title of the open position |
+
+**Optional Tags:**
+
+| Tag | Description |
+| --- | --- |
+| `description` | Description of responsibilities for the position |
+
+**Content:** Empty string or optional description text.
+
+**Example:**
+
+```json
+{
+  "kind": 39069,
+  "pubkey": "<committee-author-pubkey>",
+  "created_at": 1704067200,
+  "content": "Help coordinate speakers and manage the event calendar.",
+  "tags": [
+    ["a", "30068:<committee-pubkey>:events-committee"],
+    ["d", "speaker-coordinator-opening"],
+    ["title", "Speaker Coordinator"],
+    ["description", "Find and coordinate speakers for monthly meetups"]
+  ]
+}
+```
+
+## Client Behavior
+
+### Fetching Committees
+
+```
+{
+  "kinds": [30068],
+  "authors": ["<whitelisted-pubkeys>"]
+}
+```
+
+Clients should deduplicate by coordinate (`kind:pubkey:d-tag`), keeping the most recent event.
+
+### Fetching Members
+
+```
+{
+  "kinds": [39068],
+  "authors": ["<whitelisted-pubkeys>"],
+  "#a": ["30068:<pubkey>:<d-tag>"]
+}
+```
+
+Members should be displayed sorted by role (chair first, then vice-chair, then members), then alphabetically by name.
+
+### Fetching Openings
+
+```
+{
+  "kinds": [39069],
+  "authors": ["<whitelisted-pubkeys>"],
+  "#a": ["30068:<pubkey>:<d-tag>"]
+}
+```
+
+### Role Values
+
+Common role values and their suggested display order:
+
+| Role | Sort Priority |
+| --- | --- |
+| `chair` | 0 (first) |
+| `vice-chair` | 1 |
+| `member` | 2 |
+
+Clients may encounter custom role values not listed above — these should sort after the standard roles.
+
+### Displaying Committees
+
+1. Fetch all committee events (kind 30068)
+2. For each committee, fetch members (kind 39068) and openings (kind 39069) by `a` tag
+3. Display members grouped by role with contact info
+4. Display openings as actionable items users can express interest in
+
+## Deletion
+
+Committees, members, and openings can be deleted using NIP-09 deletion events referencing the event ID or using NIP-33 `a` tag deletion for parameterized replaceable events (kind 30068).
+
+## Access Control
+
+This NIP does not define on-chain access control. Implementations typically restrict publishing to a whitelist of authorized pubkeys maintained by the community. The `authors` filter ensures only authorized events are displayed.
+
+## References
+
+- NIP-01: Basic protocol flow
+- NIP-09: Event deletion
+- NIP-33: Parameterized replaceable events


### PR DESCRIPTION
Adds `nips/committee-structures.md` — a Nostr Implementation Proposal defining three event kinds for community committee management:

- **Kind 30068** (Committee) — parameterized replaceable, holds board metadata
- **Kind 39068** (Committee Member) — links a person + role to a committee
- **Kind 39069** (Committee Opening) — represents an open volunteer position

Also includes the README fixes from PR #130 (logo, MIT license, correct kind range — 39070/39071 don't exist in code).

The NIP spec can be copy-pasted into [NostrHub](https://nostrhub.io/create) to register it as a community NIP (requires NIP-07 login). Supersedes #130.